### PR TITLE
fix(names): fix revert names

### DIFF
--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -48,7 +48,7 @@ contract BondController is IBondController, Initializable, AccessControl {
 
         for (uint256 i = 0; i < trancheRatios.length; i++) {
             uint256 ratio = trancheRatios[i];
-            require(ratio <= TRANCHE_RATIO_GRANULARITY, "Invalid tranche ratio");
+            require(ratio <= TRANCHE_RATIO_GRANULARITY, "BondController: Invalid tranche ratio");
             totalRatio += ratio;
 
             address trancheTokenAddress =
@@ -57,8 +57,8 @@ contract BondController is IBondController, Initializable, AccessControl {
             trancheTokenAddresses[trancheTokenAddress] = true;
         }
 
-        require(totalRatio == TRANCHE_RATIO_GRANULARITY, "Invalid total tranche ratios");
-        require(_maturityDate > block.timestamp, "Invalid maturity date");
+        require(totalRatio == TRANCHE_RATIO_GRANULARITY, "BondController: Invalid tranche ratios");
+        require(_maturityDate > block.timestamp, "BondController: Invalid maturity date");
         maturityDate = _maturityDate;
     }
 
@@ -93,10 +93,10 @@ contract BondController is IBondController, Initializable, AccessControl {
      * @inheritdoc IBondController
      */
     function mature() external override {
-        require(!isMature, "Bond is already mature");
+        require(!isMature, "BondController: Already mature");
         require(
             hasRole(DEFAULT_ADMIN_ROLE, _msgSender()) || maturityDate < block.timestamp,
-            "No permissions to call mature"
+            "BondController: Invalid call to mature"
         );
 
         TrancheData[] memory _tranches = tranches;
@@ -127,8 +127,8 @@ contract BondController is IBondController, Initializable, AccessControl {
      * @inheritdoc IBondController
      */
     function redeemMature(address tranche, uint256 amount) external override {
-        require(isMature, "Bond is not mature");
-        require(trancheTokenAddresses[tranche], "Invalid tranche address");
+        require(isMature, "BondController: Bond is not mature");
+        require(trancheTokenAddresses[tranche], "BondController: Invalid tranche address");
 
         ITranche(tranche).redeem(_msgSender(), _msgSender(), amount);
         totalDebt -= amount;
@@ -139,10 +139,10 @@ contract BondController is IBondController, Initializable, AccessControl {
      * @inheritdoc IBondController
      */
     function redeem(uint256[] memory amounts) external override {
-        require(!isMature, "Bond is already mature");
+        require(!isMature, "BondController: Bond is already mature");
 
         TrancheData[] memory _tranches = tranches;
-        require(amounts.length == _tranches.length, "Invalid redeem amounts");
+        require(amounts.length == _tranches.length, "BondController: Invalid redeem amounts");
         uint256 total = 0;
 
         for (uint256 i = 0; i < amounts.length; i++) {
@@ -150,7 +150,7 @@ contract BondController is IBondController, Initializable, AccessControl {
         }
 
         for (uint256 i = 0; i < amounts.length; i++) {
-            require((amounts[i] * 1000) / total == _tranches[i].ratio, "Invalid redemption ratio");
+            require((amounts[i] * 1000) / total == _tranches[i].ratio, "BondController: Invalid redemption ratio");
             _tranches[i].token.burn(_msgSender(), amounts[i]);
         }
 

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -127,7 +127,7 @@ describe("Bond Controller", () => {
         bondFactory
           .connect(signers[0])
           .createBond(mockCollateralToken.address, [500, 500], await time.secondsFromNow(-10000)),
-      ).to.be.revertedWith("Invalid maturity date");
+      ).to.be.revertedWith("BondController: Invalid maturity date");
     });
 
     it("should fail with invalid tranche ratios", async () => {
@@ -146,25 +146,25 @@ describe("Bond Controller", () => {
       const mockCollateralToken = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
       await expect(
         bondFactory.connect(signers[0]).createBond(mockCollateralToken.address, [], await time.secondsFromNow(10000)),
-      ).to.be.revertedWith("Invalid total tranche ratios");
+      ).to.be.revertedWith("BondController: Invalid tranche ratios");
 
       await expect(
         bondFactory
           .connect(signers[0])
           .createBond(mockCollateralToken.address, [10, 20], await time.secondsFromNow(10000)),
-      ).to.be.revertedWith("Invalid total tranche ratios");
+      ).to.be.revertedWith("BondController: Invalid tranche ratios");
 
       await expect(
         bondFactory
           .connect(signers[0])
           .createBond(mockCollateralToken.address, [1005], await time.secondsFromNow(10000)),
-      ).to.be.revertedWith("Invalid tranche ratio");
+      ).to.be.revertedWith("BondController: Invalid tranche ratio");
 
       await expect(
         bondFactory
           .connect(signers[0])
           .createBond(mockCollateralToken.address, [400, 500, 900], await time.secondsFromNow(10000)),
-      ).to.be.revertedWith("Invalid total tranche ratios");
+      ).to.be.revertedWith("BondController: Invalid tranche ratios");
     });
 
     it("gas [ @skip-on-coverage ]", async () => {
@@ -434,12 +434,12 @@ describe("Bond Controller", () => {
     it("should fail to mature from admin an already mature bond", async () => {
       const { bond, admin } = await setup();
       await bond.connect(admin).mature();
-      await expect(bond.connect(admin).mature()).to.be.revertedWith("Bond is already mature");
+      await expect(bond.connect(admin).mature()).to.be.revertedWith("BondController: Already mature");
     });
 
     it("should fail to mature from user if maturity date is not passed", async () => {
       const { bond, user } = await setup();
-      await expect(bond.connect(user).mature()).to.be.revertedWith("No permissions to call mature");
+      await expect(bond.connect(user).mature()).to.be.revertedWith("BondController: Invalid call to mature");
     });
 
     it("gas [ @skip-on-coverage ]", async () => {
@@ -492,7 +492,7 @@ describe("Bond Controller", () => {
 
       await bond.connect(user).deposit(amount);
       await expect(bond.connect(user).redeemMature(tranches[0].address, parse("200"))).to.be.revertedWith(
-        "Bond is not mature",
+        "BondController: Bond is not mature",
       );
     });
 
@@ -500,7 +500,7 @@ describe("Bond Controller", () => {
       const { bond, user } = await setup();
 
       await expect(bond.connect(user).redeemMature(await user.getAddress(), parse("200"))).to.be.revertedWith(
-        "Invalid tranche address",
+        "BondController: Invalid tranche address",
       );
     });
 
@@ -589,21 +589,27 @@ describe("Bond Controller", () => {
       const { bond, user, admin } = await setup();
       await bond.connect(admin).mature();
 
-      await expect(bond.connect(user).redeem([100, 200, 200, 500])).to.be.revertedWith("Bond is already mature");
+      await expect(bond.connect(user).redeem([100, 200, 200, 500])).to.be.revertedWith(
+        "BondController: Bond is already mature",
+      );
     });
 
     it("should fail to redeem with invalid redeem amounts", async () => {
       const { bond, user } = await setup();
 
-      await expect(bond.connect(user).redeem([100, 200])).to.be.revertedWith("Invalid redeem amounts");
-      await expect(bond.connect(user).redeem([100, 200, 200, 500, 100])).to.be.revertedWith("Invalid redeem amounts");
+      await expect(bond.connect(user).redeem([100, 200])).to.be.revertedWith("BondController: Invalid redeem amounts");
+      await expect(bond.connect(user).redeem([100, 200, 200, 500, 100])).to.be.revertedWith(
+        "BondController: Invalid redeem amounts",
+      );
     });
 
     it("should fail to redeem out of ratio", async () => {
       const trancheValues = [200, 300, 500];
       const { bond, user } = await setup(trancheValues);
 
-      await expect(bond.connect(user).redeem([100, 300, 500])).to.be.revertedWith("Invalid redemption ratio");
+      await expect(bond.connect(user).redeem([100, 300, 500])).to.be.revertedWith(
+        "BondController: Invalid redemption ratio",
+      );
     });
 
     it("should fail to redeem more than owned", async () => {


### PR DESCRIPTION
This commit fixes the naming scheme for revert messages to include the
contract that threw them