### PR TITLE
fix(bond): remove magic number

### DIFF
--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -150,7 +150,10 @@ contract BondController is IBondController, Initializable, AccessControl {
         }
 
         for (uint256 i = 0; i < amounts.length; i++) {
-            require((amounts[i] * 1000) / total == _tranches[i].ratio, "BondController: Invalid redemption ratio");
+            require(
+                (amounts[i] * TRANCHE_RATIO_GRANULARITY) / total == _tranches[i].ratio,
+                "BondController: Invalid redemption ratio"
+            );
             _tranches[i].token.burn(_msgSender(), amounts[i]);
         }
 


### PR DESCRIPTION
This commit uses a static constant instead of a magic number for the
tranche ratio granularity