### PR TITLE
fix(bond): reverse cd ratio scaling

### DIFF
--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -76,9 +76,9 @@ contract BondController is IBondController, Initializable, AccessControl {
             // NOTE: solidity 0.8 checks for over/underflow natively so no need for SafeMath
             uint256 trancheValue = (amount * _tranches[i].ratio) / TRANCHE_RATIO_GRANULARITY;
 
-            // if there is any collateral, we should scale by the collateral:debt ratio
+            // if there is any collateral, we should scale by the debt:collateral ratio
             if (collateralBalance > 0) {
-                trancheValue = (trancheValue * collateralBalance) / totalDebt;
+                trancheValue = (trancheValue * totalDebt) / collateralBalance;
             }
             newDebt += trancheValue;
 

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -272,13 +272,13 @@ describe("Bond Controller", () => {
       for (let i = 0; i < tranches.length; i++) {
         const tranche = tranches[i];
         const trancheValue = parse(trancheValues[i].toString());
-        expect(await tranche.totalSupply()).to.equal(trancheValue.mul(3));
-        expect(await tranche.balanceOf(await other.getAddress())).to.equal(trancheValue.mul(2));
+        expect(await tranche.totalSupply()).to.equal(trancheValue.div(2).mul(3));
+        expect(await tranche.balanceOf(await other.getAddress())).to.equal(trancheValue.div(2));
       }
 
       expect(await mockCollateralToken.balanceOf(await other.getAddress())).to.equal(0);
       expect(await mockCollateralToken.balanceOf(bond.address)).to.equal(amount.mul(4));
-      expect(await bond.totalDebt()).to.equal(amount.mul(3));
+      expect(await bond.totalDebt()).to.equal(amount.div(2).mul(3));
     });
 
     it("should successfully deposit collateral with negative CD ratio", async () => {
@@ -303,14 +303,14 @@ describe("Bond Controller", () => {
 
       for (let i = 0; i < tranches.length; i++) {
         const tranche = tranches[i];
-        const trancheValue = parse(trancheValues[i].toString()).div(2);
+        const trancheValue = parse(trancheValues[i].toString());
         expect(await tranche.totalSupply()).to.equal(trancheValue.mul(3));
-        expect(await tranche.balanceOf(await other.getAddress())).to.equal(trancheValue);
+        expect(await tranche.balanceOf(await other.getAddress())).to.equal(trancheValue.mul(2));
       }
 
       expect(await mockCollateralToken.balanceOf(await other.getAddress())).to.equal(0);
       expect(await mockCollateralToken.balanceOf(bond.address)).to.equal(amount);
-      expect(await bond.totalDebt()).to.equal(amount.div(2).mul(3));
+      expect(await bond.totalDebt()).to.equal(amount.mul(3));
     });
 
     it("should fail to deposit collateral if not approved", async () => {


### PR DESCRIPTION
The amount of tranche tokens minted should scale by the debt:collateral
ratio, not the other way around. This means that when the price of the
underlying asset has gone down, the number of tokens the user receives
should scale up. Similarly, when the price of the underlying asset has
gone up, the number of tokens the user receives should scale down.