### PR TITLE
fix: tranche decimals

### DIFF
--- a/contracts/Tranche.sol
+++ b/contracts/Tranche.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.8.3;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "@uniswap/lib/contracts/libraries/TransferHelper.sol";
@@ -67,5 +68,20 @@ contract Tranche is ITranche, ERC20, Initializable, AccessControl {
 
         _burn(from, amount);
         TransferHelper.safeTransfer(collateralToken, to, collateralAmount);
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Uses the same number of decimals as the collateral token
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view override returns (uint8) {
+        return IERC20Metadata(collateralToken).decimals();
     }
 }

--- a/contracts/test/MockERC20CustomDecimals.sol
+++ b/contracts/test/MockERC20CustomDecimals.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+
+contract MockERC20CustomDecimals is Context, ERC20Burnable {
+    uint256 private constant MULTIPLIER_GRANULARITY = 10000;
+    uint256 public multiplier = 10000;
+    uint8 public _decimals;
+
+    /**
+     * @dev Initializes ERC20 token
+     */
+    constructor(
+        string memory name,
+        string memory symbol,
+        uint8 decimals_
+    ) ERC20(name, symbol) {
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Creates `amount` new tokens for `to`. Public for any test to call.
+     *
+     * See {ERC20-_mint}.
+     */
+    function mint(address to, uint256 amount) public virtual {
+        _mint(to, amount);
+    }
+
+    function rebase(uint256 _multiplier) external {
+        multiplier = _multiplier;
+    }
+
+    function transfer(address who, uint256 amount) public override returns (bool) {
+        // transfer actual amount with the multiplier divided out, so balances line up
+        return super.transfer(who, (amount * MULTIPLIER_GRANULARITY) / multiplier);
+    }
+
+    function balanceOf(address who) public view override returns (uint256) {
+        // multiply underlying balance to accommodate current rebase multiplier
+        return (super.balanceOf(who) * multiplier) / MULTIPLIER_GRANULARITY;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+}


### PR DESCRIPTION
This commit fixes the tranche decimal precision to match that of the
underlying collateral token. This makes the tranche token amounts easier
to read