### PR TITLE
feat: update node version for ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [12.x]
         os: [macOS-latest, windows-latest, ubuntu-latest]
 
     steps:


### PR DESCRIPTION
hardhat requires node 12 at least now -- this commit updates our ci to
run with it so it can properly install