### PR TITLE
feat: add deposit limit guardrail

### DIFF
--- a/contracts/BondFactory.sol
+++ b/contracts/BondFactory.sol
@@ -13,7 +13,6 @@ contract BondFactory is IBondFactory, Context {
 
     address public immutable target;
     address public immutable trancheFactory;
-    mapping(bytes32 => address) public bonds;
 
     constructor(address _target, address _trancheFactory) {
         target = _target;
@@ -22,20 +21,61 @@ contract BondFactory is IBondFactory, Context {
 
     /**
      * @dev Deploys a minimal proxy instance for a new bond with the given parameters.
+     * @param _collateralToken The address of the ERC20 token that the bond will use as collateral
+     * @param trancheRatios the ratios that the bond will use to generate tranche tokens
+     * @param maturityDate The unix timestamp in seconds at which the bond is maturable
+     * @return  The address of the newly created bond
      */
     function createBond(
         address _collateralToken,
         uint256[] memory trancheRatios,
         uint256 maturityDate
     ) external override returns (address) {
-        bytes32 bondHash = keccak256(abi.encodePacked(_collateralToken, maturityDate, trancheRatios));
-        require(bonds[bondHash] == address(0), "BondFactory: Bond already exists");
+        return _createBond(_collateralToken, trancheRatios, maturityDate, 0);
+    }
 
+    /**
+     * @dev Deploys a minimal proxy instance for a new bond with the given parameters.
+     * @param _collateralToken The address of the ERC20 token that the bond will use as collateral
+     * @param trancheRatios the ratios that the bond will use to generate tranche tokens
+     * @param maturityDate The unix timestamp in seconds at which the bond is maturable
+     * @param depositLimit The maximum amount of collateral that can be deposited into the bond
+     * @return  The address of the newly created bond
+     */
+    function createBondWithDepositLimit(
+        address _collateralToken,
+        uint256[] memory trancheRatios,
+        uint256 maturityDate,
+        uint256 depositLimit
+    ) external returns (address) {
+        return _createBond(_collateralToken, trancheRatios, maturityDate, depositLimit);
+    }
+
+    /**
+     * @dev Deploys a minimal proxy instance for a new bond with the given parameters.
+     * @param _collateralToken The address of the ERC20 token that the bond will use as collateral
+     * @param trancheRatios the ratios that the bond will use to generate tranche tokens
+     * @param maturityDate The unix timestamp in seconds at which the bond is maturable
+     * @param depositLimit The maximum amount of collateral that can be deposited into the bond
+     * @return  The address of the newly created bond
+     */
+    function _createBond(
+        address _collateralToken,
+        uint256[] memory trancheRatios,
+        uint256 maturityDate,
+        uint256 depositLimit
+    ) internal returns (address) {
         address clone = Clones.clone(target);
-        bonds[bondHash] = clone;
-        BondController(clone).init(trancheFactory, _collateralToken, _msgSender(), trancheRatios, maturityDate);
+        BondController(clone).init(
+            trancheFactory,
+            _collateralToken,
+            _msgSender(),
+            trancheRatios,
+            maturityDate,
+            depositLimit
+        );
 
-        emit BondCreated(clone);
+        emit BondCreated(_msgSender(), clone);
         return clone;
     }
 }

--- a/contracts/bondMinter/BondConfigVault.sol
+++ b/contracts/bondMinter/BondConfigVault.sol
@@ -30,7 +30,7 @@ contract BondConfigVault is IBondConfigVault, Ownable {
         uint256[] memory trancheRatios_,
         uint256 duration_
     ) private pure returns (bytes32) {
-        return keccak256(abi.encodePacked(collateralToken_, trancheRatios_, duration_));
+        return keccak256(abi.encode(collateralToken_, trancheRatios_, duration_));
     }
 
     /**

--- a/contracts/interfaces/IBondFactory.sol
+++ b/contracts/interfaces/IBondFactory.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.3;
  * @dev Factory for BondController minimal proxy contracts
  */
 interface IBondFactory {
-    event BondCreated(address newBondAddress);
+    event BondCreated(address creator, address newBondAddress);
 
     /**
      * @dev Deploys a minimal proxy instance for a new bond with the given parameters.

--- a/test/BondMinter.ts
+++ b/test/BondMinter.ts
@@ -89,13 +89,10 @@ describe("BondConfigVault", () => {
     it("Adding 2 bonds and minting them", async () => {
       const { bondMinter, mockBondFactory, mockUnderlyingToken } = await setupTestContext();
 
-      await expect(bondMinter.addBondConfig(mockUnderlyingToken.address, [100, 200, 700], 100));
-      await expect(bondMinter.addBondConfig(mockUnderlyingToken.address, [200, 300, 500], 300));
+      await expect(bondMinter.addBondConfig(mockUnderlyingToken.address, [100, 200, 700], 100)).to.not.be.reverted;
+      await expect(bondMinter.addBondConfig(mockUnderlyingToken.address, [200, 300, 500], 300)).to.not.be.reverted;
 
-      const blockNumBefore = await ethers.provider.getBlockNumber();
-      const blockBefore = await ethers.provider.getBlock(blockNumBefore);
-      const timestampBefore = blockBefore.timestamp;
-      const timestampAfter = timestampBefore + 999;
+      const timestampAfter = await time.secondsFromNow(999);
 
       await mockBondFactory.mock.createBond
         .withArgs(mockUnderlyingToken.address, [100, 200, 700], timestampAfter + 100)
@@ -115,12 +112,9 @@ describe("BondConfigVault", () => {
     it("Minting same bond twice after waiting the exact waiting period", async () => {
       const { bondMinter, mockBondFactory, mockUnderlyingToken } = await setupTestContext();
 
-      await expect(bondMinter.addBondConfig(mockUnderlyingToken.address, [100, 200, 700], 100));
+      await expect(bondMinter.addBondConfig(mockUnderlyingToken.address, [100, 200, 700], 100)).to.not.be.reverted;
 
-      const blockNumBefore = await ethers.provider.getBlockNumber();
-      const blockBefore = await ethers.provider.getBlock(blockNumBefore);
-      const timestampBefore = blockBefore.timestamp;
-      const timestampAfter = timestampBefore + 999;
+      const timestampAfter = await time.secondsFromNow(999);
 
       await mockBondFactory.mock.createBond
         .withArgs(mockUnderlyingToken.address, [100, 200, 700], timestampAfter + 100)
@@ -144,12 +138,9 @@ describe("BondConfigVault", () => {
     it("Minting same bond twice too soon should revert", async () => {
       const { bondMinter, mockBondFactory, mockUnderlyingToken } = await setupTestContext();
 
-      await expect(bondMinter.addBondConfig(mockUnderlyingToken.address, [100, 200, 700], 100));
+      await expect(bondMinter.addBondConfig(mockUnderlyingToken.address, [100, 200, 700], 100)).to.not.be.reverted;
 
-      const blockNumBefore = await ethers.provider.getBlockNumber();
-      const blockBefore = await ethers.provider.getBlock(blockNumBefore);
-      const timestampBefore = blockBefore.timestamp;
-      const timestampAfter = timestampBefore + 999;
+      const timestampAfter = await time.secondsFromNow(999);
 
       await mockBondFactory.mock.createBond
         .withArgs(mockUnderlyingToken.address, [100, 200, 700], timestampAfter + 100)


### PR DESCRIPTION
This commit adds a guardrail that limits the amount of collateral which
can be deposited into a given bond. It leaves this value flexible so
that the creator can set it as desired. Note that it is denominated in
terms of the underlying rebasing collateral for simplicity, so does not
exactly always translate to a dollar value. A bond can also be over the
deposit limit, then later be back below it if the collateral suffers
a negative rebase.