### PR TITLE
feat: add tranche fee

### DIFF
--- a/contracts/external/Ownable.sol
+++ b/contracts/external/Ownable.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.0 (access/Ownable.sol)
+// only change is constructor -> init so we can inherit from clones
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract Ownable is Context, Initializable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function init(address _initialOwner) internal initializer {
+        _transferOwnership(_initialOwner);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        _transferOwnership(address(0));
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     */
+    function _transferOwnership(address newOwner) internal virtual {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+}

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -391,7 +391,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("473369");
+      expect(gasUsed.toString()).to.equal("477764");
     });
   });
 });


### PR DESCRIPTION
this commit adds a fee to the tranche BondController contract. It takes
the fee off of the user's deposit, storing the fee in terms of tranche
tokens (all tranches, i.e. a slice of A, B, and Z) in the BondController
contract. All tranche tokens owned by the BondController will be
considered fee tokens. At maturity, these tokens are automatically
redeemed and the resulting underlying collateral is sent to the owner of
the contract.