### PR TITLE
feat: add leverage router

### DIFF
--- a/contracts/UniV2LeverageRouter.sol
+++ b/contracts/UniV2LeverageRouter.sol
@@ -1,0 +1,65 @@
+pragma solidity ^0.8.3;
+
+import "./interfaces/ILoanRouter.sol";
+import "./interfaces/ILeverageRouter.sol";
+import "./interfaces/IBondController.sol";
+import "./external/IUniswapV2Router.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @dev Router to create a leveraged long position, maximizing the amount of Z-tranche tokens held
+ */
+contract UniV2LeverageRouter is ILeverageRouter {
+    uint256 public constant MAX_UINT256 = type(uint256).max;
+    IUniswapV2Router public uniswapV2Router;
+
+    constructor(IUniswapV2Router _uniswapV2Router) {
+        uniswapV2Router = _uniswapV2Router;
+    }
+
+    /**
+     * @inheritdoc ILeverageRouter
+     */
+    function lever(
+        uint256 amount,
+        IBondController bond,
+        ILoanRouter loanRouter,
+        IERC20 currency,
+        address[] calldata swapBackPath,
+        uint256 iterations,
+        uint256 minOutput
+    ) external override returns (uint256 amountOut) {
+        IERC20 collateral = IERC20(bond.collateralToken());
+        require(address(collateral) != address(currency), "LeverageRouter: Invalid currency");
+
+        SafeERC20.safeTransferFrom(collateral, msg.sender, address(this), amount);
+
+        for (uint256 i = 0; i < iterations; i++) {
+            uint256 balance = collateral.balanceOf(address(this));
+            collateral.approve(address(loanRouter), balance);
+            loanRouter.borrowMax(balance, bond, currency, 0);
+
+            _swapBack(swapBackPath, currency.balanceOf(address(this)));
+        }
+
+        (IERC20 zTranche, ) = bond.tranches(bond.trancheCount() - 1);
+        amountOut = zTranche.balanceOf(address(this));
+        require(amountOut >= minOutput, "LeverageRouter: Insufficient output");
+
+        // return proceeds to the user
+        zTranche.transfer(msg.sender, amountOut);
+        collateral.transfer(msg.sender, collateral.balanceOf(address(this)));
+    }
+
+    /**
+     * @dev Swap the currency token back into the collateral token
+     * @param swapBackPath The path of tokens to swap between
+     * @param amount The amount of input tokens to swap
+     */
+    function _swapBack(address[] calldata swapBackPath, uint256 amount) internal {
+        address input = swapBackPath[0];
+        IERC20(input).approve(address(uniswapV2Router), amount);
+        uniswapV2Router.swapExactTokensForTokens(amount, 0, swapBackPath, address(this), block.timestamp);
+    }
+}

--- a/contracts/UniV2LoanRouter.sol
+++ b/contracts/UniV2LoanRouter.sol
@@ -4,16 +4,16 @@ import "./LoanRouter.sol";
 import "./interfaces/IBondController.sol";
 import "./interfaces/ITranche.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol";
+import "./external/IUniswapV2Router.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
  * @dev Loan router for the UniswapV2 AMM
  */
 contract UniV2LoanRouter is LoanRouter {
-    IUniswapV2Router02 public uniswapV2Router;
+    IUniswapV2Router public uniswapV2Router;
 
-    constructor(IUniswapV2Router02 _uniswapV2Router) {
+    constructor(IUniswapV2Router _uniswapV2Router) {
         uniswapV2Router = _uniswapV2Router;
     }
 

--- a/contracts/UniV3LoanRouter.sol
+++ b/contracts/UniV3LoanRouter.sol
@@ -4,8 +4,8 @@ import "./LoanRouter.sol";
 import "./interfaces/IBondController.sol";
 import "./interfaces/ITranche.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "./external/ISwapRouter.sol";
 
 /**
  * @dev Loan router for the UniswapV3 AMM

--- a/contracts/external/ISwapRouter.sol
+++ b/contracts/external/ISwapRouter.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+pragma abicoder v2;
+
+/// @title Router token swapping functionality
+/// @notice Functions for swapping tokens via Uniswap V3
+interface ISwapRouter {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    /// @notice Swaps `amountIn` of one token for as much as possible of another token
+    /// @param params The parameters necessary for the swap, encoded as `ExactInputSingleParams` in calldata
+    /// @return amountOut The amount of the received token
+    function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
+
+    struct ExactInputParams {
+        bytes path;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+    }
+
+    /// @notice Swaps `amountIn` of one token for as much as possible of another along the specified path
+    /// @param params The parameters necessary for the multi-hop swap, encoded as `ExactInputParams` in calldata
+    /// @return amountOut The amount of the received token
+    function exactInput(ExactInputParams calldata params) external payable returns (uint256 amountOut);
+
+    struct ExactOutputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountOut;
+        uint256 amountInMaximum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    /// @notice Swaps as little as possible of one token for `amountOut` of another token
+    /// @param params The parameters necessary for the swap, encoded as `ExactOutputSingleParams` in calldata
+    /// @return amountIn The amount of the input token
+    function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn);
+
+    struct ExactOutputParams {
+        bytes path;
+        address recipient;
+        uint256 deadline;
+        uint256 amountOut;
+        uint256 amountInMaximum;
+    }
+
+    /// @notice Swaps as little as possible of one token for `amountOut` of another along the specified path (reversed)
+    /// @param params The parameters necessary for the multi-hop swap, encoded as `ExactOutputParams` in calldata
+    /// @return amountIn The amount of the input token
+    function exactOutput(ExactOutputParams calldata params) external payable returns (uint256 amountIn);
+}

--- a/contracts/external/IUniswapV2Router.sol
+++ b/contracts/external/IUniswapV2Router.sol
@@ -1,0 +1,155 @@
+pragma solidity >=0.6.2;
+
+interface IUniswapV2Router {
+    function factory() external pure returns (address);
+
+    // solhint-disable-next-line func-name-mixedcase
+    function WETH() external pure returns (address);
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        returns (
+            uint256 amountA,
+            uint256 amountB,
+            uint256 liquidity
+        );
+
+    function addLiquidityETH(
+        address token,
+        uint256 amountTokenDesired,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        payable
+        returns (
+            uint256 amountToken,
+            uint256 amountETH,
+            uint256 liquidity
+        );
+
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountA, uint256 amountB);
+
+    function removeLiquidityETH(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountToken, uint256 amountETH);
+
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 amountA, uint256 amountB);
+
+    function removeLiquidityETHWithPermit(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 amountToken, uint256 amountETH);
+
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapTokensForExactTokens(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapExactETHForTokens(
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256[] memory amounts);
+
+    function swapTokensForExactETH(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapExactTokensForETH(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapETHForExactTokens(
+        uint256 amountOut,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256[] memory amounts);
+
+    function quote(
+        uint256 amountA,
+        uint256 reserveA,
+        uint256 reserveB
+    ) external pure returns (uint256 amountB);
+
+    function getAmountOut(
+        uint256 amountIn,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) external pure returns (uint256 amountOut);
+
+    function getAmountIn(
+        uint256 amountOut,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) external pure returns (uint256 amountIn);
+
+    function getAmountsOut(uint256 amountIn, address[] calldata path) external view returns (uint256[] memory amounts);
+
+    function getAmountsIn(uint256 amountOut, address[] calldata path) external view returns (uint256[] memory amounts);
+}

--- a/contracts/interfaces/ILeverageRouter.sol
+++ b/contracts/interfaces/ILeverageRouter.sol
@@ -1,0 +1,29 @@
+pragma solidity 0.8.3;
+
+import "./ILoanRouter.sol";
+import "./IBondController.sol";
+import "./ILoanRouter.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ILeverageRouter {
+    /**
+     * @dev Creates a leveraged long position for the user
+     * @param amount The amount of collateral to leverage
+     * @param bond The bond leverage with
+     * @param loanRouter The LoanRouter to use for accumulating Z-tranches
+     * @param currency The currency which has a uniswap pool
+     * @param swapBackPath The path to swap back from currency to collateral
+     * @param iterations The number of times to swap senior tokens for junior tokens
+     * @param minOutput The minimum amount of junior (equity) tokens expected. If less, the function reverts
+     * @return amountOut The amount of Z-tranches returned
+     */
+    function lever(
+        uint256 amount,
+        IBondController bond,
+        ILoanRouter loanRouter,
+        IERC20 currency,
+        address[] calldata swapBackPath,
+        uint256 iterations,
+        uint256 minOutput
+    ) external returns (uint256 amountOut);
+}

--- a/contracts/test/MockSwapRouter.sol
+++ b/contracts/test/MockSwapRouter.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.8.3;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+import "../external/ISwapRouter.sol";
 
 contract MockSwapRouter {
     uint256 public constant SWAP_RATE_GRANULARITY = 10000;

--- a/tasks/deployers/routers.ts
+++ b/tasks/deployers/routers.ts
@@ -18,9 +18,16 @@ task("deploy:Routers").setAction(async function (_args: TaskArguments, hre) {
 
   console.log("UniswapV2 Router deployed to: ", uniV2LoanRouter.address);
 
+  const UniV2LeverageRouter = await hre.ethers.getContractFactory("UniV2LeverageRouter");
+  const uniV2LeverageRouter = await UniV2LeverageRouter.deploy(UNISWAP_V2_ROUTER);
+  await uniV2LeverageRouter.deployed();
+
+  console.log("UniswapV2 Leverage Router deployed to: ", uniV2LeverageRouter.address);
+
   try {
     await hre.run("verify:UniLoanRouter", { address: uniV3LoanRouter.address, swapRouter: UNISWAP_V3_ROUTER });
     await hre.run("verify:UniLoanRouter", { address: uniV3LoanRouter.address, swapRouter: UNISWAP_V2_ROUTER });
+    await hre.run("verify:UniLoanRouter", { address: uniV2LeverageRouter.address, swapRouter: UNISWAP_V2_ROUTER });
   } catch (e) {
     console.log("Unable to verify on etherscan", e);
   }

--- a/test/UniV2LeverageRouter.ts
+++ b/test/UniV2LeverageRouter.ts
@@ -1,0 +1,388 @@
+import { expect } from "chai";
+import hre, { waffle } from "hardhat";
+import { Signer } from "ethers";
+import { BlockchainTime } from "./utils/time";
+import { deploy } from "./utils/contracts";
+const { loadFixture } = waffle;
+
+import {
+  MockERC20,
+  MockSwapRouter,
+  MockUniV2Router,
+  Tranche,
+  TrancheFactory,
+  BondController,
+  BondFactory,
+  UniV3LoanRouter,
+  UniV2LeverageRouter,
+} from "../typechain";
+
+interface TestContext {
+  loanRouter: UniV3LoanRouter;
+  leverageRouter: UniV2LeverageRouter;
+  mockCollateralToken: MockERC20;
+  mockCashToken: MockERC20;
+  bond: BondController;
+  tranches: Tranche[];
+  user: Signer;
+  other: Signer;
+  signers: Signer[];
+}
+
+const time = new BlockchainTime();
+
+describe("Uniswap V2 Leverage Router", () => {
+  /**
+   * Sets up a test context, deploying new contracts and returning them for use in a test
+   */
+  const fixture = async (): Promise<TestContext> => {
+    const signers: Signer[] = await hre.ethers.getSigners();
+    const [user, other, admin] = signers;
+
+    const mockSwapRouter = <MockSwapRouter>await deploy("MockSwapRouter", signers[0], []);
+    const loanRouter = <UniV3LoanRouter>await deploy("UniV3LoanRouter", signers[0], [mockSwapRouter.address]);
+
+    const mockUniV2Router = <MockUniV2Router>await deploy("MockUniV2Router", signers[0], []);
+    const leverageRouter = <UniV2LeverageRouter>(
+      await deploy("UniV2LeverageRouter", signers[0], [mockUniV2Router.address])
+    );
+
+    const mockCollateralToken = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
+    const mockCashToken = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
+
+    const trancheImplementation = <Tranche>await deploy("Tranche", admin, []);
+    const trancheFactory = <TrancheFactory>await deploy("TrancheFactory", admin, [trancheImplementation.address]);
+
+    const bondImplementation = <BondController>await deploy("BondController", admin, []);
+    const bondFactory = <BondFactory>(
+      await deploy("BondFactory", admin, [bondImplementation.address, trancheFactory.address])
+    );
+
+    const tranches = [200, 300, 500];
+    let bond: BondController | undefined;
+    const tx = await bondFactory
+      .connect(admin)
+      .createBond(mockCollateralToken.address, tranches, await time.secondsFromNow(10000));
+    const receipt = await tx.wait();
+    if (receipt && receipt.events) {
+      for (const event of receipt.events) {
+        if (event.args && event.args.newBondAddress) {
+          bond = <BondController>await hre.ethers.getContractAt("BondController", event.args.newBondAddress);
+        }
+      }
+    } else {
+      throw new Error("Unable to create new bond");
+    }
+    if (!bond) {
+      throw new Error("Unable to create new bond");
+    }
+
+    const trancheContracts: Tranche[] = [];
+    for (let i = 0; i < tranches.length; i++) {
+      const tranche = <Tranche>await hre.ethers.getContractAt("Tranche", (await bond.tranches(i)).token);
+      trancheContracts.push(tranche);
+    }
+    // load up the mock uniswap with tokens for swapping
+    await mockCollateralToken.mint(mockSwapRouter.address, hre.ethers.utils.parseEther("1000000000000"));
+    await mockCashToken.mint(mockSwapRouter.address, hre.ethers.utils.parseEther("1000000000000"));
+    await mockCollateralToken.mint(mockUniV2Router.address, hre.ethers.utils.parseEther("1000000000000"));
+    await mockCashToken.mint(mockUniV2Router.address, hre.ethers.utils.parseEther("1000000000000"));
+
+    return {
+      loanRouter,
+      leverageRouter,
+      mockCollateralToken,
+      bond,
+      tranches: trancheContracts,
+      mockCashToken,
+      user,
+      other,
+      signers: signers.slice(2),
+    };
+  };
+
+  describe("lever", function () {
+    it("should successfully lever 1 iteration", async () => {
+      const { loanRouter, leverageRouter, tranches, mockCollateralToken, mockCashToken, bond, user } =
+        await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(leverageRouter.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      // then trade those 50 cash tokens back for 50 collateral tokens
+      const minOutput = hre.ethers.utils.parseEther("50");
+      await expect(
+        leverageRouter
+          .connect(user)
+          .lever(
+            amount,
+            bond.address,
+            loanRouter.address,
+            mockCashToken.address,
+            [mockCashToken.address, mockCollateralToken.address],
+            1,
+            minOutput,
+            { gasLimit: 9500000 },
+          ),
+      )
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(await user.getAddress(), leverageRouter.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(leverageRouter.address, loanRouter.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(loanRouter.address, bond.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(leverageRouter.address, await user.getAddress(), minOutput);
+
+      expect((await mockCashToken.balanceOf(await user.getAddress())).eq(0)).to.be.true;
+      expect((await mockCollateralToken.balanceOf(await user.getAddress())).gte(minOutput)).to.be.true;
+
+      for (const tranche of tranches.slice(0, -1)) {
+        expect((await tranche.balanceOf(await user.getAddress())).eq(0)).to.be.true;
+      }
+
+      expect(
+        (await tranches[tranches.length - 1].balanceOf(await user.getAddress())).eq(hre.ethers.utils.parseEther("50")),
+      ).to.be.true;
+    });
+
+    it("should successfully lever 2 iterations", async () => {
+      const { loanRouter, leverageRouter, tranches, mockCollateralToken, mockCashToken, bond, user } =
+        await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(leverageRouter.address, amount);
+
+      // min output of 85 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      // then trade those 50 cash tokens back for 50 collateral tokens
+      // then borrow against those 50 collateral tokens, netting 10 A and 15 B tranche tokens
+      // then trade those 25 cash tokens back for 25 collateral tokens
+      const minZTrancheOutput = hre.ethers.utils.parseEther("75");
+      const minCollateralTokenOutput = hre.ethers.utils.parseEther("25");
+      await expect(
+        leverageRouter
+          .connect(user)
+          .lever(
+            amount,
+            bond.address,
+            loanRouter.address,
+            mockCashToken.address,
+            [mockCashToken.address, mockCollateralToken.address],
+            2,
+            minZTrancheOutput,
+            { gasLimit: 9500000 },
+          ),
+      )
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(await user.getAddress(), leverageRouter.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(leverageRouter.address, loanRouter.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(loanRouter.address, bond.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(leverageRouter.address, await user.getAddress(), minCollateralTokenOutput);
+
+      expect((await mockCashToken.balanceOf(await user.getAddress())).eq(0)).to.be.true;
+      expect((await mockCollateralToken.balanceOf(await user.getAddress())).gte(minCollateralTokenOutput)).to.be.true;
+
+      for (const tranche of tranches.slice(0, -1)) {
+        expect((await tranche.balanceOf(await user.getAddress())).eq(0)).to.be.true;
+      }
+
+      expect((await tranches[tranches.length - 1].balanceOf(await user.getAddress())).eq(minZTrancheOutput)).to.be.true;
+    });
+
+    it("should successfully lever 3 iterations", async () => {
+      const { loanRouter, leverageRouter, tranches, mockCollateralToken, mockCashToken, bond, user } =
+        await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(leverageRouter.address, amount);
+
+      // min output of 85 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      // then trade those 50 cash tokens back for 50 collateral tokens
+      // then borrow against those 50 collateral tokens, netting 10 A and 15 B tranche tokens
+      // then trade those 25 cash tokens back for 25 collateral tokens
+      const minZTrancheOutput = hre.ethers.utils.parseEther("87.5");
+      const minCollateralTokenOutput = hre.ethers.utils.parseEther("12.5");
+      await expect(
+        leverageRouter
+          .connect(user)
+          .lever(
+            amount,
+            bond.address,
+            loanRouter.address,
+            mockCashToken.address,
+            [mockCashToken.address, mockCollateralToken.address],
+            3,
+            minZTrancheOutput,
+            { gasLimit: 9500000 },
+          ),
+      )
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(await user.getAddress(), leverageRouter.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(leverageRouter.address, loanRouter.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(loanRouter.address, bond.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(leverageRouter.address, await user.getAddress(), minCollateralTokenOutput);
+
+      expect((await mockCashToken.balanceOf(await user.getAddress())).eq(0)).to.be.true;
+      expect((await mockCollateralToken.balanceOf(await user.getAddress())).gte(minCollateralTokenOutput)).to.be.true;
+
+      for (const tranche of tranches.slice(0, -1)) {
+        expect((await tranche.balanceOf(await user.getAddress())).eq(0)).to.be.true;
+      }
+
+      expect((await tranches[tranches.length - 1].balanceOf(await user.getAddress())).eq(minZTrancheOutput)).to.be.true;
+    });
+
+    it("should successfully lever 4 iterations", async () => {
+      const { loanRouter, leverageRouter, tranches, mockCollateralToken, mockCashToken, bond, user } =
+        await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(leverageRouter.address, amount);
+
+      // min output of 85 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      // then trade those 50 cash tokens back for 50 collateral tokens
+      // then borrow against those 50 collateral tokens, netting 10 A and 15 B tranche tokens
+      // then trade those 25 cash tokens back for 25 collateral tokens
+      const minZTrancheOutput = hre.ethers.utils.parseEther("93.75");
+      const minCollateralTokenOutput = hre.ethers.utils.parseEther("6.25");
+      await expect(
+        leverageRouter
+          .connect(user)
+          .lever(
+            amount,
+            bond.address,
+            loanRouter.address,
+            mockCashToken.address,
+            [mockCashToken.address, mockCollateralToken.address],
+            4,
+            minZTrancheOutput,
+            { gasLimit: 9500000 },
+          ),
+      )
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(await user.getAddress(), leverageRouter.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(leverageRouter.address, loanRouter.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(loanRouter.address, bond.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(leverageRouter.address, await user.getAddress(), minCollateralTokenOutput);
+
+      expect((await mockCashToken.balanceOf(await user.getAddress())).eq(0)).to.be.true;
+      expect((await mockCollateralToken.balanceOf(await user.getAddress())).gte(minCollateralTokenOutput)).to.be.true;
+
+      for (const tranche of tranches.slice(0, -1)) {
+        expect((await tranche.balanceOf(await user.getAddress())).eq(0)).to.be.true;
+      }
+
+      expect((await tranches[tranches.length - 1].balanceOf(await user.getAddress())).eq(minZTrancheOutput)).to.be.true;
+    });
+
+    it("should successfully lever 5 iterations", async () => {
+      const { loanRouter, leverageRouter, tranches, mockCollateralToken, mockCashToken, bond, user } =
+        await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(leverageRouter.address, amount);
+
+      // min output of 85 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      // then trade those 50 cash tokens back for 50 collateral tokens
+      // then borrow against those 50 collateral tokens, netting 10 A and 15 B tranche tokens
+      // then trade those 25 cash tokens back for 25 collateral tokens
+      const minZTrancheOutput = hre.ethers.utils.parseEther("96.875");
+      const minCollateralTokenOutput = hre.ethers.utils.parseEther("3.125");
+      await expect(
+        leverageRouter
+          .connect(user)
+          .lever(
+            amount,
+            bond.address,
+            loanRouter.address,
+            mockCashToken.address,
+            [mockCashToken.address, mockCollateralToken.address],
+            5,
+            minZTrancheOutput,
+            { gasLimit: 9500000 },
+          ),
+      )
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(await user.getAddress(), leverageRouter.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(leverageRouter.address, loanRouter.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(loanRouter.address, bond.address, amount)
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(leverageRouter.address, await user.getAddress(), minCollateralTokenOutput);
+
+      expect((await mockCashToken.balanceOf(await user.getAddress())).eq(0)).to.be.true;
+      expect((await mockCollateralToken.balanceOf(await user.getAddress())).gte(minCollateralTokenOutput)).to.be.true;
+
+      for (const tranche of tranches.slice(0, -1)) {
+        expect((await tranche.balanceOf(await user.getAddress())).eq(0)).to.be.true;
+      }
+
+      expect((await tranches[tranches.length - 1].balanceOf(await user.getAddress())).eq(minZTrancheOutput)).to.be.true;
+    });
+
+    it("should fail with invalid currency", async () => {
+      const { loanRouter, leverageRouter, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(leverageRouter.address, amount);
+
+      // min output of 85 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      // then trade those 50 cash tokens back for 50 collateral tokens
+      // then borrow against those 50 collateral tokens, netting 10 A and 15 B tranche tokens
+      // then trade those 25 cash tokens back for 25 collateral tokens
+      const minZTrancheOutput = hre.ethers.utils.parseEther("75");
+      await expect(
+        leverageRouter
+          .connect(user)
+          .lever(
+            amount,
+            bond.address,
+            loanRouter.address,
+            mockCollateralToken.address,
+            [mockCashToken.address, mockCollateralToken.address],
+            2,
+            minZTrancheOutput,
+            { gasLimit: 9500000 },
+          ),
+      ).to.be.revertedWith("LeverageRouter: Invalid currency");
+    });
+
+    it("should fail with insufficient output", async () => {
+      const { loanRouter, leverageRouter, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(leverageRouter.address, amount);
+
+      // min output of 85 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      // then trade those 50 cash tokens back for 50 collateral tokens
+      // then borrow against those 50 collateral tokens, netting 10 A and 15 B tranche tokens
+      // then trade those 25 cash tokens back for 25 collateral tokens
+      const minZTrancheOutput = hre.ethers.utils.parseEther("76");
+      await expect(
+        leverageRouter
+          .connect(user)
+          .lever(
+            amount,
+            bond.address,
+            loanRouter.address,
+            mockCashToken.address,
+            [mockCashToken.address, mockCollateralToken.address],
+            2,
+            minZTrancheOutput,
+            { gasLimit: 9500000 },
+          ),
+      ).to.be.revertedWith("LeverageRouter: Insufficient output");
+    });
+  });
+});


### PR DESCRIPTION
This commit adds a new router contract which repeatedly borrows and
swaps back cash for collateral to borrow again. The result is that the
user gets extra Z-tranche exposure and any leftover collateral after the
given number of iterations are complete