### PR TITLE
Bond duration

### DIFF
--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -31,6 +31,7 @@ contract BondController is IBondController, OwnableUpgradeable {
     TrancheData[] public override tranches;
     uint256 public override trancheCount;
     mapping(address => bool) public trancheTokenAddresses;
+    uint256 public creationDate;
     uint256 public maturityDate;
     bool public isMature;
     uint256 public totalDebt;
@@ -86,6 +87,7 @@ contract BondController is IBondController, OwnableUpgradeable {
 
         require(totalRatio == TRANCHE_RATIO_GRANULARITY, "BondController: Invalid tranche ratios");
         require(_maturityDate > block.timestamp, "BondController: Invalid maturity date");
+        creationDate = block.timestamp;
         maturityDate = _maturityDate;
         depositLimit = _depositLimit;
     }

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -391,7 +391,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("477917");
+      expect(gasUsed.toString()).to.equal("477943");
     });
   });
 });


### PR DESCRIPTION
Added additional parameter to bond controller to keep track of the bond duration.

Since {creationDate or duration, maturity date, collateral token, trancheRatios } together uniquely identify a Bond either the creation date or duration should be stored on the bond controller.
