### PR TITLE
Minter keeps track of minted bonds for instance check

### DIFF
--- a/contracts/bondMinter/BondMinter.sol
+++ b/contracts/bondMinter/BondMinter.sol
@@ -17,6 +17,9 @@ contract BondMinter is IBondMinter, Ownable, BondConfigVault {
     /// @notice Minimum waiting period (in second) between mints allowed
     uint256 public waitingPeriod;
 
+    /// @dev The bonds created by this minter
+    mapping(address => bool) private _mintedBonds;
+
     /**
      * @notice Constructor for IBondMinter
      * @param _bondFactory bondFactory that will be used for minting bonds
@@ -57,11 +60,22 @@ contract BondMinter is IBondMinter, Ownable, BondConfigVault {
 
         for (uint256 i = 0; i < numConfigs(); i++) {
             BondConfig memory bondConfig = bondConfigAt(i);
-            bondFactory.createBond(
+            address bond = bondFactory.createBond(
                 bondConfig.collateralToken,
                 bondConfig.trancheRatios,
                 block.timestamp + bondConfig.duration
             );
+
+            _mintedBonds[bond] = true;
+
+            emit BondMinted(bond);
         }
+    }
+
+    /**
+     * @inheritdoc IBondMinter
+     */
+    function isInstance(address bond) external view override returns (bool) {
+        return _mintedBonds[bond];
     }
 }

--- a/contracts/interfaces/IBondMinter.sol
+++ b/contracts/interfaces/IBondMinter.sol
@@ -9,6 +9,12 @@ import "./IBondFactory.sol";
  */
 interface IBondMinter is IBondConfigVault {
     /**
+     * @notice Event emitted when a new bond is minted using this minter
+     * @param bond The address of the newly minted bond
+     */
+    event BondMinted(address bond);
+
+    /**
      * @notice Sets the bondFactory
      * @param _bondFactory The bondFactory that will be used mint the bonds
      */
@@ -24,4 +30,9 @@ interface IBondMinter is IBondConfigVault {
      * @notice Iterates over configurations and mints bonds for each using the bondFactory
      */
     function mintBonds() external;
+
+    /**
+     * @notice Checks if a given bond was instantiated by the minter
+     */
+    function isInstance(address bond) external view returns (bool);
 }

--- a/test/BondMinter.ts
+++ b/test/BondMinter.ts
@@ -104,8 +104,14 @@ describe("BondConfigVault", () => {
 
       await time.setNextBlockTimestamp(timestampAfter);
 
-      await bondMinter.mintBonds();
+      expect(await bondMinter.mintBonds())
+        .to.emit(bondMinter, "BondMinted")
+        .withArgs("0x0000000000000000000000000000000000000001")
+        .to.emit(bondMinter, "BondMinted")
+        .withArgs("0x0000000000000000000000000000000000000002");
 
+      expect(await bondMinter.isInstance("0x0000000000000000000000000000000000000001")).to.be.true;
+      expect(await bondMinter.isInstance("0x0000000000000000000000000000000000000002")).to.be.true;
       expect(await bondMinter.lastMintTimestamp()).to.eq(timestampAfter);
     });
 
@@ -122,7 +128,12 @@ describe("BondConfigVault", () => {
 
       await time.setNextBlockTimestamp(timestampAfter);
 
-      await bondMinter.mintBonds();
+      expect(await bondMinter.mintBonds())
+        .to.emit(bondMinter, "BondMinted")
+        .withArgs("0x0000000000000000000000000000000000000001");
+
+      expect(await bondMinter.isInstance("0x0000000000000000000000000000000000000001")).to.be.true;
+      expect(await bondMinter.isInstance("0x0000000000000000000000000000000000000002")).to.be.false;
 
       await mockBondFactory.mock.createBond
         .withArgs(mockUnderlyingToken.address, [100, 200, 700], timestampAfter + DAYS_30 + 100)
@@ -130,7 +141,12 @@ describe("BondConfigVault", () => {
 
       await time.setNextBlockTimestamp(timestampAfter + DAYS_30);
 
-      await bondMinter.mintBonds();
+      expect(await bondMinter.mintBonds())
+        .to.emit(bondMinter, "BondMinted")
+        .withArgs("0x0000000000000000000000000000000000000002");
+
+      expect(await bondMinter.isInstance("0x0000000000000000000000000000000000000001")).to.be.true;
+      expect(await bondMinter.isInstance("0x0000000000000000000000000000000000000002")).to.be.true;
 
       expect(await bondMinter.lastMintTimestamp()).to.eq(timestampAfter + DAYS_30);
     });

--- a/test/BondMinter.ts
+++ b/test/BondMinter.ts
@@ -104,7 +104,7 @@ describe("BondConfigVault", () => {
 
       await time.setNextBlockTimestamp(timestampAfter);
 
-      expect(await bondMinter.mintBonds())
+      await expect(bondMinter.mintBonds())
         .to.emit(bondMinter, "BondMinted")
         .withArgs("0x0000000000000000000000000000000000000001")
         .to.emit(bondMinter, "BondMinted")
@@ -128,7 +128,7 @@ describe("BondConfigVault", () => {
 
       await time.setNextBlockTimestamp(timestampAfter);
 
-      expect(await bondMinter.mintBonds())
+      await expect(bondMinter.mintBonds())
         .to.emit(bondMinter, "BondMinted")
         .withArgs("0x0000000000000000000000000000000000000001");
 
@@ -141,7 +141,7 @@ describe("BondConfigVault", () => {
 
       await time.setNextBlockTimestamp(timestampAfter + DAYS_30);
 
-      expect(await bondMinter.mintBonds())
+      await expect(bondMinter.mintBonds())
         .to.emit(bondMinter, "BondMinted")
         .withArgs("0x0000000000000000000000000000000000000002");
 


### PR DESCRIPTION
Downstream services which accept bonds from a given minter need to be able to verify if a given bond was indeed minted using the minter. 

Minter keeps track of all the bond addresses minted ..