### PR TITLE
Tranche keeping track of bond controller

### DIFF
--- a/contracts/Tranche.sol
+++ b/contracts/Tranche.sol
@@ -14,12 +14,14 @@ import "./external/ERC20.sol";
  */
 contract Tranche is ITranche, ERC20, Initializable, AccessControl {
     address public collateralToken;
+    address public bondController;
 
     /**
      * @dev Constructor for Tranche ERC20 token
      */
     constructor() ERC20("IMPLEMENTATION", "IMPL") {
         collateralToken = address(0x0);
+        bondController = address(0x0);
     }
 
     /**
@@ -40,6 +42,7 @@ contract Tranche is ITranche, ERC20, Initializable, AccessControl {
         super.init(name, symbol);
         _setupRole(DEFAULT_ADMIN_ROLE, admin);
         collateralToken = _collateralToken;
+        bondController = admin;
     }
 
     /**

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -211,7 +211,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("914307");
+      expect(gasUsed.toString()).to.equal("980835");
     });
   });
 
@@ -438,7 +438,7 @@ describe("Bond Controller", () => {
       const tx = await bond.connect(user).deposit(amount);
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("270967");
+      expect(gasUsed.toString()).to.equal("271033");
     });
   });
 
@@ -550,7 +550,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("226644");
+      expect(gasUsed.toString()).to.equal("226487");
     });
   });
 
@@ -918,7 +918,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("81436");
+      expect(gasUsed.toString()).to.equal("81458");
     });
   });
 
@@ -1035,7 +1035,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("119720");
+      expect(gasUsed.toString()).to.equal("119615");
     });
   });
 });

--- a/test/Tranche.ts
+++ b/test/Tranche.ts
@@ -63,6 +63,7 @@ describe("Tranche Token", () => {
       expect(await tranche.decimals()).to.equal(18);
       // ensure user has admin permissions
       expect(await tranche.hasRole(hre.ethers.constants.HashZero, await user.getAddress())).to.be.true;
+      expect(await tranche.bondController()).to.eq(await user.getAddress());
     });
 
     it("should fail to initialize with zero address collateralToken", async () => {
@@ -81,6 +82,7 @@ describe("Tranche Token", () => {
       expect(await tranche.decimals()).to.equal(8);
       // ensure user has admin permissions
       expect(await tranche.hasRole(hre.ethers.constants.HashZero, await user.getAddress())).to.be.true;
+      expect(await tranche.bondController()).to.eq(await user.getAddress());
     });
   });
 

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -391,7 +391,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("478356");
+      expect(gasUsed.toString()).to.equal("478217");
     });
   });
 });


### PR DESCRIPTION
Individual tranches need a way to reference the parent bond controller.

Without this downstream contracts which deal with individual tranches need to keep track of both the bond address and the tranche address ..