### PR TITLE
feat: use owner for tranche

### DIFF
--- a/contracts/Tranche.sol
+++ b/contracts/Tranche.sol
@@ -2,18 +2,18 @@ pragma solidity 0.8.3;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import "@openzeppelin/contracts/access/AccessControl.sol";
-import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "@uniswap/lib/contracts/libraries/TransferHelper.sol";
+import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "./interfaces/ITranche.sol";
 import "./external/ERC20.sol";
 
 /**
  * @dev ERC20 token to represent a single tranche for a ButtonTranche bond
- *
+ * Note: this contract has non-transferrable ownership given at init-time
  */
-contract Tranche is ITranche, ERC20, Initializable, AccessControl {
+contract Tranche is ITranche, ERC20, Initializable {
     address public collateralToken;
+    address public override bond;
 
     /**
      * @dev Constructor for Tranche ERC20 token
@@ -26,33 +26,43 @@ contract Tranche is ITranche, ERC20, Initializable, AccessControl {
      * @dev Constructor for Tranche ERC20 token
      * @param name the ERC20 token name
      * @param symbol The ERC20 token symbol
-     * @param admin The admin of this ERC20 token
+     * @param _bond The BondController which owns this Tranche token
      * @param _collateralToken The address of the ERC20 collateral token
      */
     function init(
         string memory name,
         string memory symbol,
-        address admin,
+        address _bond,
         address _collateralToken
     ) public initializer {
-        require(admin != address(0), "Tranche: invalid admin address");
+        require(_bond != address(0), "Tranche: invalid bond address");
         require(_collateralToken != address(0), "Tranche: invalid collateralToken address");
-        super.init(name, symbol);
-        _setupRole(DEFAULT_ADMIN_ROLE, admin);
+
+        bond = _bond;
         collateralToken = _collateralToken;
+
+        super.init(name, symbol);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the bond.
+     */
+    modifier onlyBond() {
+        require(bond == _msgSender(), "Ownable: caller is not the bond");
+        _;
     }
 
     /**
      * @inheritdoc ITranche
      */
-    function mint(address to, uint256 amount) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+    function mint(address to, uint256 amount) external override onlyBond {
         _mint(to, amount);
     }
 
     /**
      * @inheritdoc ITranche
      */
-    function burn(address from, uint256 amount) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+    function burn(address from, uint256 amount) external override onlyBond {
         _burn(from, amount);
     }
 
@@ -63,7 +73,7 @@ contract Tranche is ITranche, ERC20, Initializable, AccessControl {
         address from,
         address to,
         uint256 amount
-    ) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+    ) external override onlyBond {
         // calculate collateral return value as the proportion of total supply redeemed
         // NOTE: solidity 0.8 has built-in overflow checking so SafeMath is not necessary
         uint256 collateralAmount = (IERC20(collateralToken).balanceOf(address(this)) * amount) / totalSupply();

--- a/contracts/interfaces/ITranche.sol
+++ b/contracts/interfaces/ITranche.sol
@@ -10,6 +10,12 @@ import "@uniswap/lib/contracts/libraries/TransferHelper.sol";
  */
 interface ITranche is IERC20 {
     /**
+     * @dev returns the BondController address which owns this Tranche contract
+     *  It should have admin permissions to call mint, burn, and redeem functions
+     */
+    function bond() external view returns (address);
+
+    /**
      * @dev Mint `amount` tokens to `to`
      *  Only callable by the owner (bond controller). Used to
      *  manage bonds, specifically creating tokens upon deposit

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -116,7 +116,7 @@ describe("Bond Controller", () => {
         const tranche = tranches[i];
         const letter = i === tranches.length - 1 ? "Z" : LETTERS[i];
         expect(await tranche.collateralToken()).to.equal(mockCollateralToken.address);
-        expect(await tranche.hasRole(hre.ethers.constants.HashZero, bond.address)).to.be.true;
+        expect(await tranche.bond()).to.equal(bond.address);
         expect(await tranche.symbol()).to.equal(`TRANCHE-${await mockCollateralToken.symbol()}-${letter}`);
         expect(await tranche.name()).to.equal(`ButtonTranche ${await mockCollateralToken.symbol()} ${letter}`);
       }
@@ -211,7 +211,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("914307");
+      expect(gasUsed.toString()).to.equal("841569");
     });
   });
 
@@ -438,7 +438,7 @@ describe("Bond Controller", () => {
       const tx = await bond.connect(user).deposit(amount);
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("270967");
+      expect(gasUsed.toString()).to.equal("270529");
     });
   });
 
@@ -550,7 +550,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("226644");
+      expect(gasUsed.toString()).to.equal("226124");
     });
   });
 
@@ -918,7 +918,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("81436");
+      expect(gasUsed.toString()).to.equal("81294");
     });
   });
 
@@ -1035,7 +1035,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("119720");
+      expect(gasUsed.toString()).to.equal("119161");
     });
   });
 });

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -391,7 +391,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("478356");
+      expect(gasUsed.toString()).to.equal("477917");
     });
   });
 });


### PR DESCRIPTION
This commit switches from accesscontrol to an owner variable for Tranche
tokens. Given that the owner is non-transferrable and necessarily always
has to be the Bond contract, this is a fair tradeoff. Pretty decent gas
improvement as well