### PR TITLE
feat: add auto-wrapping to loan router

### DIFF
--- a/contracts/interfaces/IButtonWrapper.sol
+++ b/contracts/interfaces/IButtonWrapper.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// from https://github.com/buttonwood-protocol/button-wrappers
+
+// Interface definition for ButtonWrapper contract, which wraps an
+// underlying ERC20 token into a new ERC20 with different characteristics.
+// NOTE: "uAmount" => underlying token (wrapped) amount and
+//       "amount" => wrapper token amount
+interface IButtonWrapper {
+    /// @notice Transfers underlying tokens from {msg.sender} to the contract and
+    ///         mints wrapper tokens to the specified beneficiary.
+    /// @param uAmount The amount of underlying tokens to deposit.
+    /// @return The amount of wrapper tokens mint.
+    function deposit(uint256 uAmount) external returns (uint256);
+
+    /// @return The address of the underlying token.
+    function underlying() external view returns (address);
+}

--- a/contracts/interfaces/ILoanRouter.sol
+++ b/contracts/interfaces/ILoanRouter.sol
@@ -7,6 +7,41 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  * @dev Router for creating loans with tranche
  */
 interface ILoanRouter {
+    /**
+     * @dev Borrow against a given bond, wrapping the raw collateral into a ButtonToken first
+     * @param underlyingAmount The amount of collateral to deposit into the bond
+     * @param currency The asset to borrow
+     * @param sales The number of tranche tokens to sell, in tranche index order
+     * @param minOutput The minimum amount of currency to get out, reverts if not met
+     */
+    function wrapAndBorrow(
+        uint256 underlyingAmount,
+        IBondController bond,
+        IERC20 currency,
+        uint256[] memory sales,
+        uint256 minOutput
+    ) external returns (uint256 amountOut);
+
+    /**
+     * @dev Borrow as much as possible against a given bond, wrapping the raw collateral into a ButtonToken first
+     * @param underlyingAmount The amount of collateral to deposit into the bond
+     * @param currency The asset to borrow
+     * @param minOutput The minimum amount of currency to get out, reverts if not met
+     */
+    function wrapAndBorrowMax(
+        uint256 underlyingAmount,
+        IBondController bond,
+        IERC20 currency,
+        uint256 minOutput
+    ) external returns (uint256 amountOut);
+
+    /**
+     * @dev Borrow against a given bond
+     * @param amount The amount of collateral to deposit into the bond
+     * @param currency The asset to borrow
+     * @param sales The number of tranche tokens to sell, in tranche index order
+     * @param minOutput The minimum amount of currency to get out, reverts if not met
+     */
     function borrow(
         uint256 amount,
         IBondController bond,
@@ -15,6 +50,12 @@ interface ILoanRouter {
         uint256 minOutput
     ) external returns (uint256 amountOut);
 
+    /**
+     * @dev Borrow as much as possible against a given bond
+     * @param amount The amount of collateral to deposit into the bond
+     * @param currency The asset to borrow
+     * @param minOutput The minimum amount of currency to get out, reverts if not met
+     */
     function borrowMax(
         uint256 amount,
         IBondController bond,

--- a/contracts/test/MockButtonWrapper.sol
+++ b/contracts/test/MockButtonWrapper.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/IButtonWrapper.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract MockButtonWrapper is Context, ERC20Burnable, IButtonWrapper {
+    uint256 private constant MULTIPLIER_GRANULARITY = 10000;
+    uint256 public multiplier = 10000;
+    IERC20 public _underlying;
+
+    /**
+     * @dev Initializes ERC20 token
+     */
+    constructor(
+        IERC20 underlying_,
+        string memory name,
+        string memory symbol
+    ) ERC20(name, symbol) {
+        _underlying = underlying_;
+    }
+
+    /**
+     * @inheritdoc IButtonWrapper
+     * @dev Mints 1 for 1
+     */
+    function deposit(uint256 uAmount) external override returns (uint256) {
+        SafeERC20.safeTransferFrom(_underlying, msg.sender, address(this), uAmount);
+        _mint(msg.sender, uAmount);
+        return uAmount;
+    }
+
+    /**
+     * @dev Creates `amount` new tokens for `to`. Public for any test to call.
+     *
+     * See {ERC20-_mint}.
+     */
+    function mint(address to, uint256 amount) public virtual {
+        _mint(to, amount);
+    }
+
+    function rebase(uint256 _multiplier) external {
+        multiplier = _multiplier;
+    }
+
+    function transfer(address who, uint256 amount) public override returns (bool) {
+        // transfer actual amount with the multiplier divided out, so balances line up
+        return super.transfer(who, (amount * MULTIPLIER_GRANULARITY) / multiplier);
+    }
+
+    function balanceOf(address who) public view override returns (uint256) {
+        // multiply underlying balance to accommodate current rebase multiplier
+        return (super.balanceOf(who) * multiplier) / MULTIPLIER_GRANULARITY;
+    }
+
+    function underlying() external view override returns (address) {
+        return address(_underlying);
+    }
+}

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -7,6 +7,7 @@ const { loadFixture } = waffle;
 
 import {
   MockERC20,
+  MockButtonWrapper,
   MockSwapRouter,
   Tranche,
   TrancheFactory,
@@ -36,11 +37,11 @@ describe("Uniswap V3 Loan Router", () => {
     const signers: Signer[] = await hre.ethers.getSigners();
     const [user, other, admin] = signers;
 
-    const mockSwapRouter = <MockSwapRouter>await deploy("MockSwapRouter", signers[0], []);
-    const router = <UniV3LoanRouter>await deploy("UniV3LoanRouter", signers[0], [mockSwapRouter.address]);
+    const mockSwapRouter = <MockSwapRouter>await deploy("MockSwapRouter", admin, []);
+    const router = <UniV3LoanRouter>await deploy("UniV3LoanRouter", admin, [mockSwapRouter.address]);
 
-    const mockCollateralToken = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
-    const mockCashToken = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
+    const mockCollateralToken = <MockERC20>await deploy("MockERC20", admin, ["Mock ERC20", "MOCK"]);
+    const mockCashToken = <MockERC20>await deploy("MockERC20", admin, ["Mock ERC20", "MOCK"]);
 
     const trancheImplementation = <Tranche>await deploy("Tranche", admin, []);
     const trancheFactory = <TrancheFactory>await deploy("TrancheFactory", admin, [trancheImplementation.address]);
@@ -391,7 +392,494 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("476028");
+      expect(gasUsed.toString()).to.equal("476050");
+    });
+  });
+});
+
+interface WrapperTestContext {
+  router: UniV3LoanRouter;
+  mockCollateralToken: MockERC20;
+  mockWrapperToken: MockButtonWrapper;
+  bondFactory: BondFactory;
+  mockCashToken: MockERC20;
+  bond: BondController;
+  tranches: Tranche[];
+  user: Signer;
+  other: Signer;
+  signers: Signer[];
+}
+
+describe("Uniswap V3 Loan Router with wrapper", () => {
+  /**
+   * Sets up a test context, deploying new contracts and returning them for use in a test
+   */
+  const fixture = async (): Promise<WrapperTestContext> => {
+    const signers: Signer[] = await hre.ethers.getSigners();
+    const [user, other, admin] = signers;
+
+    const mockSwapRouter = <MockSwapRouter>await deploy("MockSwapRouter", user, []);
+    const router = <UniV3LoanRouter>await deploy("UniV3LoanRouter", admin, [mockSwapRouter.address]);
+
+    const mockCollateralToken = <MockERC20>await deploy("MockERC20", admin, ["Mock ERC20", "MOCK"]);
+    const mockWrapperToken = <MockButtonWrapper>(
+      await deploy("MockButtonWrapper", admin, [mockCollateralToken.address, "Mock ERC20", "MOCK"])
+    );
+    const mockCashToken = <MockERC20>await deploy("MockERC20", admin, ["Mock ERC20", "MOCK"]);
+
+    const trancheImplementation = <Tranche>await deploy("Tranche", admin, []);
+    const trancheFactory = <TrancheFactory>await deploy("TrancheFactory", admin, [trancheImplementation.address]);
+
+    const bondImplementation = <BondController>await deploy("BondController", admin, []);
+    const bondFactory = <BondFactory>(
+      await deploy("BondFactory", admin, [bondImplementation.address, trancheFactory.address])
+    );
+
+    const tranches = [200, 300, 500];
+    let bond: BondController | undefined;
+    const tx = await bondFactory
+      .connect(admin)
+      .createBond(mockWrapperToken.address, tranches, await time.secondsFromNow(10000));
+    const receipt = await tx.wait();
+    if (receipt && receipt.events) {
+      for (const event of receipt.events) {
+        if (event.args && event.args.newBondAddress) {
+          bond = <BondController>await hre.ethers.getContractAt("BondController", event.args.newBondAddress);
+        }
+      }
+    } else {
+      throw new Error("Unable to create new bond");
+    }
+    if (!bond) {
+      throw new Error("Unable to create new bond");
+    }
+
+    const trancheContracts: Tranche[] = [];
+    for (let i = 0; i < tranches.length; i++) {
+      const tranche = <Tranche>await hre.ethers.getContractAt("Tranche", (await bond.tranches(i)).token);
+      trancheContracts.push(tranche);
+    }
+    // load up the mock uniswap with tokens for swapping
+    await mockCollateralToken.mint(mockSwapRouter.address, hre.ethers.utils.parseEther("1000000000000"));
+    await mockCashToken.mint(mockSwapRouter.address, hre.ethers.utils.parseEther("1000000000000"));
+
+    return {
+      router,
+      mockCollateralToken,
+      mockWrapperToken,
+      bond,
+      bondFactory,
+      tranches: trancheContracts,
+      mockCashToken,
+      user,
+      other,
+      signers: signers.slice(2),
+    };
+  };
+
+  describe("wrapAndBorrowMax", function () {
+    it("should successfully wrap and borrow max", async () => {
+      const { router, tranches, mockCollateralToken, mockWrapperToken, mockCashToken, bond, user } = await loadFixture(
+        fixture,
+      );
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // Note: the mock AMM swaps at a 1:1 ratio
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("50");
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrowMax(amount, bond.address, mockCashToken.address, minOutput, { gasLimit: 9500000 }),
+      )
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(await user.getAddress(), router.address, amount)
+        // Note: the mock wrapper wraps at a 1:1 ratio, thus the wrapped output is equal to the input
+        .to.emit(mockWrapperToken, "Transfer")
+        .withArgs(router.address, bond.address, amount)
+        .to.emit(mockCashToken, "Transfer")
+        .withArgs(router.address, await user.getAddress(), minOutput);
+
+      expect((await mockCashToken.balanceOf(await user.getAddress())).gte(minOutput)).to.be.true;
+
+      for (const tranche of tranches.slice(0, -1)) {
+        expect((await tranche.balanceOf(await user.getAddress())).eq(0)).to.be.true;
+      }
+
+      expect(
+        (await tranches[tranches.length - 1].balanceOf(await user.getAddress())).eq(hre.ethers.utils.parseEther("50")),
+      ).to.be.true;
+    });
+
+    it("should fetch amountOut from a static call", async () => {
+      const { router, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("50");
+      const amountOut = await router
+        .connect(user)
+        .callStatic.wrapAndBorrowMax(amount, bond.address, mockCashToken.address, minOutput);
+      expect(minOutput).to.equal(amountOut);
+    });
+
+    it("should fail if not a wrapper token", async () => {
+      const { router, mockCollateralToken, mockCashToken, bondFactory, user } = await loadFixture(fixture);
+
+      // deploy a new bond factory with a non-wrapper collateral
+      let bond: BondController | undefined;
+      const tx = await bondFactory.createBond(
+        mockCollateralToken.address,
+        [200, 300, 500],
+        await time.secondsFromNow(10000),
+      );
+      const receipt = await tx.wait();
+      if (receipt && receipt.events) {
+        for (const event of receipt.events) {
+          if (event.args && event.args.newBondAddress) {
+            bond = <BondController>await hre.ethers.getContractAt("BondController", event.args.newBondAddress);
+          }
+        }
+      } else {
+        throw new Error("Unable to create new bond");
+      }
+      if (!bond) {
+        throw new Error("Unable to create new bond");
+      }
+
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrowMax(amount, bond.address, mockCashToken.address, hre.ethers.utils.parseEther("50"), {
+            gasLimit: 9500000,
+          }),
+      ).to.be.revertedWith(
+        "Transaction reverted: function selector was not recognized and there's no fallback function",
+      );
+    });
+
+    it("should fail if not approved", async () => {
+      const { router, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrowMax(amount, bond.address, mockCashToken.address, hre.ethers.utils.parseEther("50"), {
+            gasLimit: 9500000,
+          }),
+      ).to.be.revertedWith("ERC20: transfer amount exceeds allowance");
+    });
+
+    it("should fail if more than balance", async () => {
+      const { router, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount.div(2));
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrowMax(amount, bond.address, mockCashToken.address, hre.ethers.utils.parseEther("50"), {
+            gasLimit: 9500000,
+          }),
+      ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
+    });
+
+    it("should fail if not enough input", async () => {
+      const { router, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("80");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrowMax(amount, bond.address, mockCashToken.address, hre.ethers.utils.parseEther("50"), {
+            gasLimit: 9500000,
+          }),
+      ).to.be.revertedWith("LoanRouter: Insufficient output");
+    });
+  });
+
+  describe("borrow", function () {
+    it("should successfully wrap and borrow", async () => {
+      const { router, tranches, mockCollateralToken, mockWrapperToken, mockCashToken, bond, user } = await loadFixture(
+        fixture,
+      );
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            amount,
+            bond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10"), 0],
+            minOutput,
+            { gasLimit: 9500000 },
+          ),
+      )
+        .to.emit(mockCollateralToken, "Transfer")
+        .withArgs(await user.getAddress(), router.address, amount)
+        .to.emit(mockWrapperToken, "Transfer")
+        .withArgs(router.address, bond.address, amount)
+        .to.emit(mockCashToken, "Transfer")
+        .withArgs(router.address, await user.getAddress(), minOutput);
+
+      expect((await mockCashToken.balanceOf(await user.getAddress())).gte(minOutput)).to.be.true;
+
+      const expected = [0, hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("50")];
+      for (let i = 0; i < tranches.length; i++) {
+        const tranche = tranches[i];
+        expect((await tranche.balanceOf(await user.getAddress())).eq(expected[i])).to.be.true;
+      }
+    });
+
+    it("should fetch amountOut from a static call", async () => {
+      const { router, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      const amountOut = await router
+        .connect(user)
+        .callStatic.wrapAndBorrow(
+          amount,
+          bond.address,
+          mockCashToken.address,
+          [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10"), 0],
+          minOutput,
+          { gasLimit: 9500000 },
+        );
+      expect(minOutput).to.equal(amountOut);
+    });
+
+    it("should fail if not approved", async () => {
+      const { router, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            amount,
+            bond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10"), 0],
+            minOutput,
+            { gasLimit: 9500000 },
+          ),
+      ).to.be.revertedWith("ERC20: transfer amount exceeds allowance");
+    });
+
+    it("should fail if more than balance", async () => {
+      const { router, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount.div(2));
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            amount,
+            bond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10"), 0],
+            minOutput,
+            { gasLimit: 9500000 },
+          ),
+      ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
+    });
+
+    it("should fail if not a wrapper token", async () => {
+      const { router, mockCollateralToken, mockCashToken, bondFactory, user } = await loadFixture(fixture);
+
+      // deploy a new bond factory with a non-wrapper collateral
+      let bond: BondController | undefined;
+      const tx = await bondFactory.createBond(
+        mockCollateralToken.address,
+        [200, 300, 500],
+        await time.secondsFromNow(10000),
+      );
+      const receipt = await tx.wait();
+      if (receipt && receipt.events) {
+        for (const event of receipt.events) {
+          if (event.args && event.args.newBondAddress) {
+            bond = <BondController>await hre.ethers.getContractAt("BondController", event.args.newBondAddress);
+          }
+        }
+      } else {
+        throw new Error("Unable to create new bond");
+      }
+      if (!bond) {
+        throw new Error("Unable to create new bond");
+      }
+
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            amount,
+            bond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10"), 0],
+            hre.ethers.utils.parseEther("50"),
+            {
+              gasLimit: 9500000,
+            },
+          ),
+      ).to.be.revertedWith(
+        "Transaction reverted: function selector was not recognized and there's no fallback function",
+      );
+    });
+
+    it("should fail if less than minOutput", async () => {
+      const { router, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            amount,
+            bond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("5"), 0],
+            minOutput,
+            { gasLimit: 9500000 },
+          ),
+      ).to.be.revertedWith("LoanRouter: Insufficient output");
+    });
+
+    it("should fail if too many amounts", async () => {
+      const { router, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            amount,
+            bond.address,
+            mockCashToken.address,
+            [
+              hre.ethers.utils.parseEther("20"),
+              hre.ethers.utils.parseEther("5"),
+              hre.ethers.utils.parseEther("5"),
+              hre.ethers.utils.parseEther("5"),
+            ],
+            minOutput,
+            { gasLimit: 9500000 },
+          ),
+      ).to.be.revertedWith("Invalid sales");
+    });
+
+    it("should fail if not enough sales", async () => {
+      const { router, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            amount,
+            bond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10")],
+            minOutput,
+            { gasLimit: 9500000 },
+          ),
+      ).to.be.reverted;
+    });
+
+    it("should fail if sale too high", async () => {
+      const { router, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            amount,
+            bond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("25"), hre.ethers.utils.parseEther("5"), 0],
+            minOutput,
+            { gasLimit: 9500000 },
+          ),
+      ).to.be.reverted;
+    });
+
+    it("gas [ @skip-on-coverage ]", async () => {
+      const { router, mockCollateralToken, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+      await mockCollateralToken.connect(user).mint(await user.getAddress(), amount);
+      await mockCollateralToken.connect(user).approve(router.address, amount);
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      const tx = await router
+        .connect(user)
+        .wrapAndBorrow(
+          amount,
+          bond.address,
+          mockCashToken.address,
+          [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10"), 0],
+          minOutput,
+          { gasLimit: 9500000 },
+        );
+
+      const receipt = await tx.wait();
+      const gasUsed = receipt.gasUsed;
+      expect(gasUsed.toString()).to.equal("561648");
     });
   });
 });


### PR DESCRIPTION
This commit adds auto-wrapping functionality to loan router, where it
can take the underlying asset, wrap it, and use that as the basis for
a loan. We still need some auto-unwrap-on-redemption feature, which can
be in a separate RedemptionUnwrapper contract or something.

Ticket: PROM-101 close