### PR TITLE
feat(eth-loan-router): adding eth-wrapping-loan-router

### DIFF
--- a/contracts/WethLoanRouter.sol
+++ b/contracts/WethLoanRouter.sol
@@ -1,0 +1,88 @@
+pragma solidity ^0.8.3;
+
+import "./interfaces/IWethLoanRouter.sol";
+import "./interfaces/ILoanRouter.sol";
+import "./interfaces/IBondController.sol";
+import "./interfaces/ITranche.sol";
+import "./interfaces/IButtonWrapper.sol";
+// ToDo: @mark-toda, Do you want me to import this from button-wrappers or copy interface here
+import "./interfaces/IWETH.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @dev Weth Loan Router built on top of a LoanRouter of your choosing
+ * to allow loans to be created with raw ETH instead of WETH
+ */
+contract WethLoanRouter is IWethLoanRouter {
+    ILoanRouter public loanRouter;
+    IWETH9 public weth;
+
+    constructor(ILoanRouter _loanRouter, IWETH9 _weth) {
+        loanRouter = _loanRouter;
+        weth = _weth;
+    }
+
+    function _wethWrap(IBondController bond) internal returns (uint256) {
+        // Confirm that ETH was sent
+        uint256 value = msg.value;
+        require(value > 0, "ButtonTokenWethRouter: No ETH supplied");
+
+        // Confirm that bond's collateral has WETH as underlying
+        IButtonWrapper wrapper = IButtonWrapper(bond.collateralToken());
+        require(wrapper.underlying() == address(weth), "Collateral Token underlying does not match WETH address.");
+
+        // Wrapping ETH into weth
+        weth.deposit{ value: value }();
+
+        // Approve loanRouter to take weth
+        uint256 wethBalance = weth.balanceOf(address(this));
+        weth.approve(address(loanRouter), wethBalance);
+        return wethBalance;
+    }
+
+    function _distributeLoanOutput(
+        uint256 amountOut,
+        IBondController bond,
+        IERC20 currency
+    ) internal {
+        // Send loan currenncy out from this contract to msg.sender
+        SafeERC20.safeTransfer(currency, msg.sender, amountOut);
+
+        // Send out the tranche tokens from this contract to the msg.sender
+        ITranche tranche;
+        for (uint256 i = 0; i < bond.trancheCount(); i++) {
+            (tranche, ) = bond.tranches(i);
+            SafeERC20.safeTransfer(tranche, msg.sender, tranche.balanceOf(address(this)));
+        }
+    }
+
+    /**
+     * @inheritdoc IWethLoanRouter
+     */
+    function wrapAndBorrow(
+        IBondController bond,
+        IERC20 currency,
+        uint256[] memory sales,
+        uint256 minOutput
+    ) external payable override returns (uint256 amountOut) {
+        uint256 wethBalance = _wethWrap(bond);
+        uint256 loanAmountOut = loanRouter.wrapAndBorrow(wethBalance, bond, currency, sales, minOutput);
+        _distributeLoanOutput(loanAmountOut, bond, currency);
+        return loanAmountOut;
+    }
+
+    /**
+     * @inheritdoc IWethLoanRouter
+     */
+    function wrapAndBorrowMax(
+        IBondController bond,
+        IERC20 currency,
+        uint256 minOutput
+    ) external payable override returns (uint256 amountOut) {
+        uint256 wethBalance = _wethWrap(bond);
+        uint256 loanAmountOut = loanRouter.wrapAndBorrowMax(wethBalance, bond, currency, minOutput);
+        _distributeLoanOutput(loanAmountOut, bond, currency);
+        return loanAmountOut;
+    }
+}

--- a/contracts/WethLoanRouter.sol
+++ b/contracts/WethLoanRouter.sol
@@ -5,7 +5,6 @@ import "./interfaces/ILoanRouter.sol";
 import "./interfaces/IBondController.sol";
 import "./interfaces/ITranche.sol";
 import "./interfaces/IButtonWrapper.sol";
-// ToDo: @mark-toda, Do you want me to import this from button-wrappers or copy interface here
 import "./interfaces/IWETH.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -15,46 +14,17 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
  * to allow loans to be created with raw ETH instead of WETH
  */
 contract WethLoanRouter is IWethLoanRouter {
-    ILoanRouter public loanRouter;
-    IWETH9 public weth;
+    ILoanRouter public immutable loanRouter;
+    IWETH9 public immutable weth;
 
+    /**
+     * @dev Constructor for setting underlying loanRouter and weth contracts
+     * @param _loanRouter The underlying loanRouter that does all the wrapping and trading
+     * @param _weth The WETH contract to wrap ETH in
+     */
     constructor(ILoanRouter _loanRouter, IWETH9 _weth) {
         loanRouter = _loanRouter;
         weth = _weth;
-    }
-
-    function _wethWrap(IBondController bond) internal returns (uint256) {
-        // Confirm that ETH was sent
-        uint256 value = msg.value;
-        require(value > 0, "ButtonTokenWethRouter: No ETH supplied");
-
-        // Confirm that bond's collateral has WETH as underlying
-        IButtonWrapper wrapper = IButtonWrapper(bond.collateralToken());
-        require(wrapper.underlying() == address(weth), "Collateral Token underlying does not match WETH address.");
-
-        // Wrapping ETH into weth
-        weth.deposit{ value: value }();
-
-        // Approve loanRouter to take weth
-        uint256 wethBalance = weth.balanceOf(address(this));
-        weth.approve(address(loanRouter), wethBalance);
-        return wethBalance;
-    }
-
-    function _distributeLoanOutput(
-        uint256 amountOut,
-        IBondController bond,
-        IERC20 currency
-    ) internal {
-        // Send loan currenncy out from this contract to msg.sender
-        SafeERC20.safeTransfer(currency, msg.sender, amountOut);
-
-        // Send out the tranche tokens from this contract to the msg.sender
-        ITranche tranche;
-        for (uint256 i = 0; i < bond.trancheCount(); i++) {
-            (tranche, ) = bond.tranches(i);
-            SafeERC20.safeTransfer(tranche, msg.sender, tranche.balanceOf(address(this)));
-        }
     }
 
     /**
@@ -84,5 +54,50 @@ contract WethLoanRouter is IWethLoanRouter {
         uint256 loanAmountOut = loanRouter.wrapAndBorrowMax(wethBalance, bond, currency, minOutput);
         _distributeLoanOutput(loanAmountOut, bond, currency);
         return loanAmountOut;
+    }
+
+    /**
+     * @dev Wraps the ETH that was transferred to this contract and then approves loanRouter for entire amount
+     * @param bond The bond that is being borrowed from
+     * @return WETH balance that was wrapped. Equal to loanRouter allowance for WETH.
+     */
+    function _wethWrap(IBondController bond) internal returns (uint256) {
+        // Confirm that ETH was sent
+        uint256 value = msg.value;
+        require(value > 0, "ButtonTokenWethRouter: No ETH supplied");
+
+        // Confirm that bond's collateral has WETH as underlying
+        IButtonWrapper wrapper = IButtonWrapper(bond.collateralToken());
+        require(wrapper.underlying() == address(weth), "Collateral Token underlying does not match WETH address.");
+
+        // Wrapping ETH into weth
+        weth.deposit{ value: value }();
+
+        // Approve loanRouter to take weth
+        uint256 wethBalance = weth.balanceOf(address(this));
+        weth.approve(address(loanRouter), wethBalance);
+        return wethBalance;
+    }
+
+    /**
+     * @dev Distributes tranche balances and borrowed amounts to end-user
+     * @param amountOut The output amount that is being borrowed
+     * @param bond The bond that is being borrowed from
+     * @param currency The asset being borrowed
+     */
+    function _distributeLoanOutput(
+        uint256 amountOut,
+        IBondController bond,
+        IERC20 currency
+    ) internal {
+        // Send loan currenncy out from this contract to msg.sender
+        SafeERC20.safeTransfer(currency, msg.sender, amountOut);
+
+        // Send out the tranche tokens from this contract to the msg.sender
+        ITranche tranche;
+        for (uint256 i = 0; i < bond.trancheCount(); i++) {
+            (tranche, ) = bond.tranches(i);
+            SafeERC20.safeTransfer(tranche, msg.sender, tranche.balanceOf(address(this)));
+        }
     }
 }

--- a/contracts/interfaces/ILoanRouter.sol
+++ b/contracts/interfaces/ILoanRouter.sol
@@ -10,6 +10,7 @@ interface ILoanRouter {
     /**
      * @dev Borrow against a given bond, wrapping the raw collateral into a ButtonToken first
      * @param underlyingAmount The amount of collateral to deposit into the bond
+     * @param bond The bond to borrow from
      * @param currency The asset to borrow
      * @param sales The number of tranche tokens to sell, in tranche index order
      * @param minOutput The minimum amount of currency to get out, reverts if not met
@@ -25,6 +26,7 @@ interface ILoanRouter {
     /**
      * @dev Borrow as much as possible against a given bond, wrapping the raw collateral into a ButtonToken first
      * @param underlyingAmount The amount of collateral to deposit into the bond
+     * @param bond The bond to borrow from
      * @param currency The asset to borrow
      * @param minOutput The minimum amount of currency to get out, reverts if not met
      */
@@ -38,6 +40,7 @@ interface ILoanRouter {
     /**
      * @dev Borrow against a given bond
      * @param amount The amount of collateral to deposit into the bond
+     * @param bond The bond to borrow from
      * @param currency The asset to borrow
      * @param sales The number of tranche tokens to sell, in tranche index order
      * @param minOutput The minimum amount of currency to get out, reverts if not met
@@ -53,6 +56,7 @@ interface ILoanRouter {
     /**
      * @dev Borrow as much as possible against a given bond
      * @param amount The amount of collateral to deposit into the bond
+     * @param bond The bond to borrow from
      * @param currency The asset to borrow
      * @param minOutput The minimum amount of currency to get out, reverts if not met
      */

--- a/contracts/interfaces/IWETH.sol
+++ b/contracts/interfaces/IWETH.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// from https://github.com/buttonwood-protocol/button-wrappers
+
+// Interface definition for WETH contract, which wraps ETH into an ERC20 token.
+interface IWETH9 {
+    function deposit() external payable;
+
+    function balanceOf(address) external view returns (uint256);
+
+    function approve(address guy, uint256 wad) external returns (bool);
+
+    function transfer(address dst, uint256 wad) external returns (bool);
+
+    function transferFrom(
+        address src,
+        address dst,
+        uint256 wad
+    ) external returns (bool);
+}

--- a/contracts/interfaces/IWethLoanRouter.sol
+++ b/contracts/interfaces/IWethLoanRouter.sol
@@ -1,0 +1,36 @@
+pragma solidity 0.8.3;
+
+import "./IBondController.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @dev Router for creating loans with tranche
+ */
+interface IWethLoanRouter {
+    /**
+     * @dev Borrow against a given bond, wrapping the raw ETH collateral into a WETH ButtonToken first
+     * @param bond The bond to borrow from
+     * @param currency The asset to borrow
+     * @param sales The number of tranche tokens to sell, in tranche index order
+     * @param minOutput The minimum amount of currency to get out, reverts if not met
+     */
+    function wrapAndBorrow(
+        IBondController bond,
+        IERC20 currency,
+        uint256[] memory sales,
+        uint256 minOutput
+    ) external payable returns (uint256 amountOut);
+
+    /**
+     * @dev Borrow as much as possible against a given bond,
+     *  wrapping the raw ETH collateral into a WETH ButtonToken first
+     * @param bond The bond to borrow from
+     * @param currency The asset to borrow
+     * @param minOutput The minimum amount of currency to get out, reverts if not met
+     */
+    function wrapAndBorrowMax(
+        IBondController bond,
+        IERC20 currency,
+        uint256 minOutput
+    ) external payable returns (uint256 amountOut);
+}

--- a/contracts/interfaces/IWethLoanRouter.sol
+++ b/contracts/interfaces/IWethLoanRouter.sol
@@ -8,7 +8,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  */
 interface IWethLoanRouter {
     /**
-     * @dev Borrow against a given bond, wrapping the raw ETH collateral into a WETH ButtonToken first
+     * @notice Borrow against a given bond, wrapping the raw ETH collateral into a WETH ButtonToken first
      * @param bond The bond to borrow from
      * @param currency The asset to borrow
      * @param sales The number of tranche tokens to sell, in tranche index order
@@ -22,7 +22,7 @@ interface IWethLoanRouter {
     ) external payable returns (uint256 amountOut);
 
     /**
-     * @dev Borrow as much as possible against a given bond,
+     * @notice Borrow as much as possible against a given bond,
      *  wrapping the raw ETH collateral into a WETH ButtonToken first
      * @param bond The bond to borrow from
      * @param currency The asset to borrow

--- a/contracts/test/WETH9.sol
+++ b/contracts/test/WETH9.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.3;
+
+contract WETH9 {
+    string public name = "Wrapped Ether";
+    string public symbol = "WETH";
+    uint8 public decimals = 18;
+    uint256 public constant MAX_UINT = type(uint256).max;
+
+    event Approval(address indexed src, address indexed guy, uint256 wad);
+    event Transfer(address indexed src, address indexed dst, uint256 wad);
+    event Deposit(address indexed dst, uint256 wad);
+    event Withdrawal(address indexed src, uint256 wad);
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function deposit() public payable {
+        balanceOf[msg.sender] += msg.value;
+        emit Deposit(msg.sender, msg.value);
+    }
+
+    function withdraw(uint256 wad) public {
+        require(balanceOf[msg.sender] >= wad, "Insufficient balance");
+        balanceOf[msg.sender] -= wad;
+        payable(msg.sender).transfer(wad);
+        emit Withdrawal(msg.sender, wad);
+    }
+
+    function totalSupply() public view returns (uint256) {
+        return address(this).balance;
+    }
+
+    function approve(address guy, uint256 wad) public returns (bool) {
+        allowance[msg.sender][guy] = wad;
+        emit Approval(msg.sender, guy, wad);
+        return true;
+    }
+
+    function transfer(address dst, uint256 wad) public returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+
+    function transferFrom(
+        address src,
+        address dst,
+        uint256 wad
+    ) public returns (bool) {
+        require(balanceOf[src] >= wad, "Insufficient balance");
+
+        if (src != msg.sender && allowance[src][msg.sender] != MAX_UINT) {
+            require(allowance[src][msg.sender] >= wad, "Insufficient allowance");
+            allowance[src][msg.sender] -= wad;
+        }
+
+        balanceOf[src] -= wad;
+        balanceOf[dst] += wad;
+
+        emit Transfer(src, dst, wad);
+
+        return true;
+    }
+}

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -392,7 +392,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("481972");
+      expect(gasUsed.toString()).to.equal("481981");
     });
   });
 });

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -392,7 +392,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("481981");
+      expect(gasUsed.toString()).to.equal("481972");
     });
   });
 });

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -533,7 +533,7 @@ describe("Uniswap V3 Loan Router with wrapper", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("692150");
+      expect(gasUsed.toString()).to.equal("692089");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -35,7 +35,7 @@ interface TestContext {
 
 const time = new BlockchainTime();
 
-describe("Uniswap V3 Loan Router with wrapper", () => {
+describe("WETH Loan Router", () => {
   /**
    * Sets up a test context, deploying new contracts and returning them for use in a test
    */

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -1,0 +1,544 @@
+import { expect } from "chai";
+import hre, { waffle } from "hardhat";
+import { Signer } from "ethers";
+import { BlockchainTime } from "./utils/time";
+import { deploy } from "./utils/contracts";
+const { loadFixture } = waffle;
+
+import {
+  MockERC20,
+  MockButtonWrapper,
+  MockSwapRouter,
+  Tranche,
+  TrancheFactory,
+  BondController,
+  BondFactory,
+  WethLoanRouter,
+  UniV3LoanRouter,
+  WETH9,
+} from "../typechain";
+
+interface TestContext {
+  router: WethLoanRouter;
+  loanRouter: UniV3LoanRouter;
+  weth: WETH9;
+  mockWrapperToken: MockButtonWrapper;
+  bondFactory: BondFactory;
+  mockCashToken: MockERC20;
+  bond: BondController;
+  tranches: Tranche[];
+  user: Signer;
+  other: Signer;
+  admin: Signer;
+  signers: Signer[];
+}
+
+const time = new BlockchainTime();
+
+describe("Uniswap V3 Loan Router with wrapper", () => {
+  /**
+   * Sets up a test context, deploying new contracts and returning them for use in a test
+   */
+  const fixture = async (): Promise<TestContext> => {
+    const signers: Signer[] = await hre.ethers.getSigners();
+    const [user, other, admin] = signers;
+
+    const mockSwapRouter = <MockSwapRouter>await deploy("MockSwapRouter", user, []);
+    const loanRouter = <UniV3LoanRouter>await deploy("UniV3LoanRouter", admin, [mockSwapRouter.address]);
+    const weth = <WETH9>await deploy("WETH9", admin, []);
+    const router = <WethLoanRouter>await deploy("WethLoanRouter", admin, [loanRouter.address, weth.address]);
+
+    const mockWrapperToken = <MockButtonWrapper>(
+      await deploy("MockButtonWrapper", admin, [weth.address, "Mock Button WETH", "MOCK-BTN-WETH"])
+    );
+    const mockCashToken = <MockERC20>await deploy("MockERC20", admin, ["Mock ERC20", "MOCK-USDT"]);
+
+    const trancheImplementation = <Tranche>await deploy("Tranche", admin, []);
+    const trancheFactory = <TrancheFactory>await deploy("TrancheFactory", admin, [trancheImplementation.address]);
+
+    const bondImplementation = <BondController>await deploy("BondController", admin, []);
+    const bondFactory = <BondFactory>(
+      await deploy("BondFactory", admin, [bondImplementation.address, trancheFactory.address])
+    );
+
+    const tranches = [200, 300, 500];
+    let bond: BondController | undefined;
+    const tx = await bondFactory
+      .connect(admin)
+      .createBond(mockWrapperToken.address, tranches, await time.secondsFromNow(10000));
+    const receipt = await tx.wait();
+    if (receipt && receipt.events) {
+      for (const event of receipt.events) {
+        if (event.args && event.args.newBondAddress) {
+          bond = <BondController>await hre.ethers.getContractAt("BondController", event.args.newBondAddress);
+        }
+      }
+    } else {
+      throw new Error("Unable to create new bond");
+    }
+    if (!bond) {
+      throw new Error("Unable to create new bond");
+    }
+
+    const trancheContracts: Tranche[] = [];
+    for (let i = 0; i < tranches.length; i++) {
+      const tranche = <Tranche>await hre.ethers.getContractAt("Tranche", (await bond.tranches(i)).token);
+      trancheContracts.push(tranche);
+    }
+    // load up the mock uniswap with tokens for swapping
+    // ToDo: @mark-toda Why do the wrapper-tests in the other loan routers do this with the collateral and not wrapper token?
+    // await mockCollateralToken.mint(mockSwapRouter.address, hre.ethers.utils.parseEther("1000000000000"));
+    await mockCashToken.mint(mockSwapRouter.address, hre.ethers.utils.parseEther("1000000000000"));
+
+    return {
+      router,
+      loanRouter,
+      weth,
+      mockWrapperToken,
+      bond,
+      bondFactory,
+      tranches: trancheContracts,
+      mockCashToken,
+      user,
+      other,
+      admin,
+      signers: signers.slice(2),
+    };
+  };
+
+  describe("wrapAndBorrowMax", function () {
+    it("should successfully wrap and borrow max", async () => {
+      const { router, loanRouter, tranches, weth, mockWrapperToken, mockCashToken, bond, user } = await loadFixture(
+        fixture,
+      );
+      const startingBalance = await user.getBalance();
+      const amount = hre.ethers.utils.parseEther("100");
+
+      // Note: the mock AMM swaps at a 1:1 ratio
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("50");
+
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrowMax(bond.address, mockCashToken.address, minOutput, { value: amount, gasLimit: 9500000 }),
+      )
+        // // Note: the mock wrapper wraps at a 1:1 ratio, thus the wrapped output is equal to the input
+        .to.emit(weth, "Transfer")
+        .withArgs(router.address, loanRouter.address, amount)
+        .to.emit(mockWrapperToken, "Transfer")
+        .withArgs(loanRouter.address, bond.address, amount)
+        .to.emit(mockCashToken, "Transfer")
+        .withArgs(loanRouter.address, router.address, minOutput)
+        .to.emit(mockCashToken, "Transfer")
+        .withArgs(router.address, await user.getAddress(), minOutput);
+
+      expect((await mockCashToken.balanceOf(await user.getAddress())).gte(minOutput)).to.be.true;
+
+      for (const tranche of tranches.slice(0, -1)) {
+        expect((await tranche.balanceOf(await user.getAddress())).eq(0)).to.be.true;
+      }
+
+      expect(
+        (await tranches[tranches.length - 1].balanceOf(await user.getAddress())).eq(hre.ethers.utils.parseEther("50")),
+      ).to.be.true;
+
+      expect(await user.getBalance()).to.lte(
+        startingBalance.sub(amount),
+        `User ETH balance should have decreased by at least ${amount.toString()}`,
+      );
+    });
+
+    it("should fetch amountOut from a static call", async () => {
+      const { router, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("50");
+      const amountOut = await router
+        .connect(user)
+        .callStatic.wrapAndBorrowMax(bond.address, mockCashToken.address, minOutput, { value: amount });
+      expect(minOutput).to.equal(amountOut);
+    });
+
+    it("should fail if not a wrapper token", async () => {
+      const { router, mockCashToken, bondFactory, user } = await loadFixture(fixture);
+
+      // deploy a new bond factory with a non-wrapper collateral
+      let bond: BondController | undefined;
+      const tx = await bondFactory.createBond(mockCashToken.address, [200, 300, 500], await time.secondsFromNow(10000));
+      const receipt = await tx.wait();
+      if (receipt && receipt.events) {
+        for (const event of receipt.events) {
+          if (event.args && event.args.newBondAddress) {
+            bond = <BondController>await hre.ethers.getContractAt("BondController", event.args.newBondAddress);
+          }
+        }
+      } else {
+        throw new Error("Unable to create new bond");
+      }
+      if (!bond) {
+        throw new Error("Unable to create new bond");
+      }
+
+      const amount = hre.ethers.utils.parseEther("100");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      await expect(
+        router.connect(user).wrapAndBorrowMax(bond.address, mockCashToken.address, hre.ethers.utils.parseEther("50"), {
+          value: amount,
+          gasLimit: 9500000,
+        }),
+      ).to.be.revertedWith(
+        "Transaction reverted: function selector was not recognized and there's no fallback function",
+      );
+    });
+
+    it("should fail if bond's collateral token's underlying does not match weth address", async () => {
+      const { router, mockCashToken, bondFactory, user, admin } = await loadFixture(fixture);
+
+      const mockButtonCash = <MockButtonWrapper>(
+        await deploy("MockButtonWrapper", admin, [mockCashToken.address, "Mock Button USDT", "MOCK-BTN-USDT"])
+      );
+
+      const tranches = [200, 300, 500];
+      let wrappedCashTokenBond: BondController | undefined;
+      const tx = await bondFactory
+        .connect(admin)
+        .createBond(mockButtonCash.address, tranches, await time.secondsFromNow(10000));
+      const receipt = await tx.wait();
+      if (receipt && receipt.events) {
+        for (const event of receipt.events) {
+          if (event.args && event.args.newBondAddress) {
+            wrappedCashTokenBond = <BondController>(
+              await hre.ethers.getContractAt("BondController", event.args.newBondAddress)
+            );
+          }
+        }
+      } else {
+        throw new Error("Unable to create new bond");
+      }
+      if (!wrappedCashTokenBond) {
+        throw new Error("Unable to create new bond");
+      }
+
+      const amount = hre.ethers.utils.parseEther("100");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrowMax(wrappedCashTokenBond.address, mockCashToken.address, hre.ethers.utils.parseEther("50"), {
+            value: amount,
+            gasLimit: 9500000,
+          }),
+      ).to.be.revertedWith("Collateral Token underlying does not match WETH address.");
+    });
+
+    it("should fail if no eth sent", async () => {
+      const { router, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("0");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      await expect(
+        router.connect(user).wrapAndBorrowMax(bond.address, mockCashToken.address, hre.ethers.utils.parseEther("50"), {
+          value: amount,
+          gasLimit: 9500000,
+        }),
+      ).to.be.revertedWith("ButtonTokenWethRouter: No ETH supplied");
+    });
+
+    it("should fail if not enough input", async () => {
+      const { router, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("80");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      await expect(
+        router.connect(user).wrapAndBorrowMax(bond.address, mockCashToken.address, hre.ethers.utils.parseEther("50"), {
+          value: amount,
+          gasLimit: 9500000,
+        }),
+      ).to.be.revertedWith("LoanRouter: Insufficient output");
+    });
+  });
+
+  describe("borrow", function () {
+    it("should successfully wrap and borrow", async () => {
+      const { router, loanRouter, tranches, weth, mockWrapperToken, mockCashToken, bond, user } = await loadFixture(
+        fixture,
+      );
+      const startingBalance = await user.getBalance();
+      const amount = hre.ethers.utils.parseEther("100");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            bond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10"), 0],
+            minOutput,
+            { value: amount, gasLimit: 9500000 },
+          ),
+      )
+        .to.emit(weth, "Transfer")
+        .withArgs(router.address, loanRouter.address, amount)
+        .to.emit(mockWrapperToken, "Transfer")
+        .withArgs(loanRouter.address, bond.address, amount)
+        .to.emit(mockCashToken, "Transfer")
+        .withArgs(loanRouter.address, router.address, minOutput)
+        .to.emit(mockCashToken, "Transfer")
+        .withArgs(router.address, await user.getAddress(), minOutput);
+
+      expect((await mockCashToken.balanceOf(await user.getAddress())).gte(minOutput)).to.be.true;
+
+      const expected = [0, hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("50")];
+      for (let i = 0; i < tranches.length; i++) {
+        const tranche = tranches[i];
+        expect((await tranche.balanceOf(await user.getAddress())).eq(expected[i])).to.be.true;
+      }
+
+      expect(await user.getBalance()).to.lte(
+        startingBalance.sub(amount),
+        `User ETH balance should have decreased by at least ${amount.toString()}`,
+      );
+    });
+
+    it("should fetch amountOut from a static call", async () => {
+      const { router, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      const amountOut = await router
+        .connect(user)
+        .callStatic.wrapAndBorrow(
+          bond.address,
+          mockCashToken.address,
+          [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10"), 0],
+          minOutput,
+          { value: amount, gasLimit: 9500000 },
+        );
+      expect(minOutput).to.equal(amountOut);
+    });
+
+    it("should fail if not a wrapper token", async () => {
+      const { router, mockCashToken, bondFactory, user } = await loadFixture(fixture);
+
+      // deploy a new bond factory with a non-wrapper collateral
+      let bond: BondController | undefined;
+      const tx = await bondFactory.createBond(mockCashToken.address, [200, 300, 500], await time.secondsFromNow(10000));
+      const receipt = await tx.wait();
+      if (receipt && receipt.events) {
+        for (const event of receipt.events) {
+          if (event.args && event.args.newBondAddress) {
+            bond = <BondController>await hre.ethers.getContractAt("BondController", event.args.newBondAddress);
+          }
+        }
+      } else {
+        throw new Error("Unable to create new bond");
+      }
+      if (!bond) {
+        throw new Error("Unable to create new bond");
+      }
+
+      const amount = hre.ethers.utils.parseEther("100");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            bond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10"), 0],
+            hre.ethers.utils.parseEther("50"),
+            {
+              value: amount,
+              gasLimit: 9500000,
+            },
+          ),
+      ).to.be.revertedWith(
+        "Transaction reverted: function selector was not recognized and there's no fallback function",
+      );
+    });
+
+    it("should fail if bond's collateral token's underlying does not match weth address", async () => {
+      const { router, mockCashToken, bondFactory, user, admin } = await loadFixture(fixture);
+
+      const mockButtonCash = <MockButtonWrapper>(
+        await deploy("MockButtonWrapper", admin, [mockCashToken.address, "Mock Button USDT", "MOCK-BTN-USDT"])
+      );
+
+      const tranches = [200, 300, 500];
+      let wrappedCashTokenBond: BondController | undefined;
+      const tx = await bondFactory
+        .connect(admin)
+        .createBond(mockButtonCash.address, tranches, await time.secondsFromNow(10000));
+      const receipt = await tx.wait();
+      if (receipt && receipt.events) {
+        for (const event of receipt.events) {
+          if (event.args && event.args.newBondAddress) {
+            wrappedCashTokenBond = <BondController>(
+              await hre.ethers.getContractAt("BondController", event.args.newBondAddress)
+            );
+          }
+        }
+      } else {
+        throw new Error("Unable to create new bond");
+      }
+      if (!wrappedCashTokenBond) {
+        throw new Error("Unable to create new bond");
+      }
+
+      const amount = hre.ethers.utils.parseEther("100");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            wrappedCashTokenBond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10"), 0],
+            hre.ethers.utils.parseEther("50"),
+            {
+              value: amount,
+              gasLimit: 9500000,
+            },
+          ),
+      ).to.be.revertedWith("Collateral Token underlying does not match WETH address.");
+    });
+
+    it("should fail if no eth sent", async () => {
+      const { router, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("0");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            bond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10"), 0],
+            hre.ethers.utils.parseEther("50"),
+            {
+              value: amount,
+              gasLimit: 9500000,
+            },
+          ),
+      ).to.be.revertedWith("ButtonTokenWethRouter: No ETH supplied");
+    });
+
+    it("should fail if less than minOutput", async () => {
+      const { router, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            bond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("5"), 0],
+            minOutput,
+            { value: amount, gasLimit: 9500000 },
+          ),
+      ).to.be.revertedWith("LoanRouter: Insufficient output");
+    });
+
+    it("should fail if too many amounts", async () => {
+      const { router, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            bond.address,
+            mockCashToken.address,
+            [
+              hre.ethers.utils.parseEther("20"),
+              hre.ethers.utils.parseEther("5"),
+              hre.ethers.utils.parseEther("5"),
+              hre.ethers.utils.parseEther("5"),
+            ],
+            minOutput,
+            { value: amount, gasLimit: 9500000 },
+          ),
+      ).to.be.revertedWith("Invalid sales");
+    });
+
+    it("should fail if not enough sales", async () => {
+      const { router, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            bond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10")],
+            minOutput,
+            { value: amount, gasLimit: 9500000 },
+          ),
+      ).to.be.reverted;
+    });
+
+    it("should fail if sale too high", async () => {
+      const { router, mockCashToken, bond, user } = await loadFixture(fixture);
+      const amount = hre.ethers.utils.parseEther("100");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      await expect(
+        router
+          .connect(user)
+          .wrapAndBorrow(
+            bond.address,
+            mockCashToken.address,
+            [hre.ethers.utils.parseEther("25"), hre.ethers.utils.parseEther("5"), 0],
+            minOutput,
+            { value: amount, gasLimit: 9500000 },
+          ),
+      ).to.be.reverted;
+    });
+
+    it("gas [ @skip-on-coverage ]", async () => {
+      const { router, mockCashToken, bond, user } = await loadFixture(fixture);
+      const startingBalance = await user.getBalance();
+      const amount = hre.ethers.utils.parseEther("100");
+
+      // min output of 50 because the router will sell all A (20) and B (30) tranche tokens, but keep the Z tranches
+      const minOutput = hre.ethers.utils.parseEther("30");
+      const tx = await router
+        .connect(user)
+        .wrapAndBorrow(
+          bond.address,
+          mockCashToken.address,
+          [hre.ethers.utils.parseEther("20"), hre.ethers.utils.parseEther("10"), 0],
+          minOutput,
+          { value: amount, gasLimit: 9500000 },
+        );
+
+      const receipt = await tx.wait();
+      const gasUsed = receipt.gasUsed;
+      expect(gasUsed.toString()).to.equal("692150");
+      const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
+      expect(await user.getBalance()).to.eq(
+        startingBalance.sub(amount).sub(costOfGas),
+        "Expecting userBalance to equal startingBalance - amount - costOfGas.",
+      );
+    });
+  });
+});

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -533,7 +533,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("692089");
+      expect(gasUsed.toString()).to.equal("688342");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),


### PR DESCRIPTION
## Changes:
- Adding `EthLoanRouter` that auto-wraps ETH into WETH before sending it to existing LoanRouter

## Tests:
- [x] Wrote unit test suite for ETH-specific transactions

## Reviewers:
@marktoda 
@Fiddlekins 