### PR TITLE
Prom 281 wampl loan router

### DIFF
--- a/contracts/WamplLoanRouter.sol
+++ b/contracts/WamplLoanRouter.sol
@@ -7,7 +7,8 @@ import "./interfaces/IButtonWrapper.sol";
 import "./interfaces/IWAMPL.sol";
 import "./interfaces/IWamplLoanRouter.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
+import "@rari-capital/solmate/src/tokens/ERC20.sol";
 
 /**
  * @dev Wampl Loan Router built on top of a LoanRouter of your choosing
@@ -16,7 +17,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 contract WamplLoanRouter is IWamplLoanRouter {
     ILoanRouter public immutable loanRouter;
     IWAMPL public immutable wampl;
-    IERC20 public immutable ampl;
+    ERC20 public immutable ampl;
 
     /**
      * @dev Constructor for setting underlying loanRouter and wampl contracts
@@ -27,7 +28,7 @@ contract WamplLoanRouter is IWamplLoanRouter {
         loanRouter = _loanRouter;
         wampl = _wampl;
         // Accessing AMPL contract from WAMPL contract
-        ampl = IERC20(_wampl.underlying());
+        ampl = ERC20(_wampl.underlying());
     }
 
     /**
@@ -73,7 +74,7 @@ contract WamplLoanRouter is IWamplLoanRouter {
         require(amplAmount > 0, "WamplLoanRouter: No AMPL supplied");
 
         // Transferring AMPL to contract
-        SafeERC20.safeTransferFrom(ampl, msg.sender, address(this), amplAmount);
+        SafeTransferLib.safeTransferFrom(ampl, msg.sender, address(this), amplAmount);
 
         // Wrapping contract's balance of AMPL into WAMPL
         ampl.approve(address(wampl), amplAmount);
@@ -96,13 +97,13 @@ contract WamplLoanRouter is IWamplLoanRouter {
         IERC20 currency
     ) internal {
         // Send loan currenncy out from this contract to msg.sender
-        SafeERC20.safeTransfer(currency, msg.sender, amountOut);
+        SafeTransferLib.safeTransfer(ERC20(address(currency)), msg.sender, amountOut);
 
         // Send out the tranche tokens from this contract to the msg.sender
         ITranche tranche;
         for (uint256 i = 0; i < bond.trancheCount(); i++) {
             (tranche, ) = bond.tranches(i);
-            SafeERC20.safeTransfer(tranche, msg.sender, tranche.balanceOf(address(this)));
+            SafeTransferLib.safeTransfer(ERC20(address(tranche)), msg.sender, tranche.balanceOf(address(this)));
         }
     }
 }

--- a/contracts/WamplLoanRouter.sol
+++ b/contracts/WamplLoanRouter.sol
@@ -40,7 +40,7 @@ contract WamplLoanRouter is IWamplLoanRouter {
         uint256[] memory sales,
         uint256 minOutput
     ) external override returns (uint256 amountOut) {
-        uint256 wamplBalance = _wamplWrapAndApprove(amplAmount, bond);
+        uint256 wamplBalance = _wamplWrapAndApprove(amplAmount);
         uint256 loanAmountOut = loanRouter.wrapAndBorrow(wamplBalance, bond, currency, sales, minOutput);
         require(loanAmountOut >= minOutput, "WamplLoanRouter: Insufficient output");
         _distributeLoanOutput(loanAmountOut, bond, currency);
@@ -56,7 +56,7 @@ contract WamplLoanRouter is IWamplLoanRouter {
         IERC20 currency,
         uint256 minOutput
     ) external override returns (uint256 amountOut) {
-        uint256 wamplBalance = _wamplWrapAndApprove(amplAmount, bond);
+        uint256 wamplBalance = _wamplWrapAndApprove(amplAmount);
         uint256 loanAmountOut = loanRouter.wrapAndBorrowMax(wamplBalance, bond, currency, minOutput);
         require(loanAmountOut >= minOutput, "WamplLoanRouter: Insufficient output");
         _distributeLoanOutput(loanAmountOut, bond, currency);
@@ -66,10 +66,9 @@ contract WamplLoanRouter is IWamplLoanRouter {
     /**
      * @dev Wraps the AMPL that was transferred to this contract and then approves loanRouter for entire amount
      * @dev No need to check that bond's collateral has WAMPL as underlying since deposit will fail otherwise
-     * @param bond The bond that is being borrowed from
      * @return WAMPL balance that was wrapped. Equal to loanRouter allowance for WAMPL.
      */
-    function _wamplWrapAndApprove(uint256 amplAmount, IBondController bond) internal returns (uint256) {
+    function _wamplWrapAndApprove(uint256 amplAmount) internal returns (uint256) {
         // Confirm that AMPL was sent
         require(amplAmount > 0, "WamplLoanRouter: No AMPL supplied");
 

--- a/contracts/WamplLoanRouter.sol
+++ b/contracts/WamplLoanRouter.sol
@@ -1,0 +1,107 @@
+pragma solidity ^0.8.3;
+
+import "./interfaces/ILoanRouter.sol";
+import "./interfaces/IBondController.sol";
+import "./interfaces/ITranche.sol";
+import "./interfaces/IButtonWrapper.sol";
+import "./interfaces/IWAMPL.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "./interfaces/IWamplLoanRouter.sol";
+
+/**
+ * @dev Wampl Loan Router built on top of a LoanRouter of your choosing
+ * to allow loans to be created with raw ampl instead of WAMPL
+ */
+contract WamplLoanRouter is IWamplLoanRouter {
+    ILoanRouter public immutable loanRouter;
+    IWAMPL public immutable wampl;
+
+    /**
+     * @dev Constructor for setting underlying loanRouter and wampl contracts
+     * @param _loanRouter The underlying loanRouter that does all the wrapping and trading
+     * @param _wampl The WAMPL contract to wrap AMPL in
+     */
+    constructor(ILoanRouter _loanRouter, IWAMPL _wampl) {
+        loanRouter = _loanRouter;
+        wampl = _wampl;
+    }
+
+    /**
+     * @inheritdoc IWamplLoanRouter
+     */
+    function wrapAndBorrow(
+        uint256 underlyingAmount,
+        IBondController bond,
+        IERC20 currency,
+        uint256[] memory sales,
+        uint256 minOutput
+    ) external payable override returns (uint256 amountOut) {
+        uint256 wamplBalance = _wamplWrap(underlyingAmount, bond);
+        uint256 loanAmountOut = loanRouter.wrapAndBorrow(wamplBalance, bond, currency, sales, minOutput);
+        _distributeLoanOutput(loanAmountOut, bond, currency);
+        return loanAmountOut;
+    }
+
+    /**
+     * @inheritdoc IWamplLoanRouter
+     */
+    function wrapAndBorrowMax(
+        uint256 underlyingAmount,
+        IBondController bond,
+        IERC20 currency,
+        uint256 minOutput
+    ) external payable override returns (uint256 amountOut) {
+        uint256 wamplBalance = _wamplWrap(underlyingAmount, bond);
+        uint256 loanAmountOut = loanRouter.wrapAndBorrowMax(wamplBalance, bond, currency, minOutput);
+        _distributeLoanOutput(loanAmountOut, bond, currency);
+        return loanAmountOut;
+    }
+
+    /**
+     * @dev Wraps the AMPL that was transferred to this contract and then approves loanRouter for entire amount
+     * @param bond The bond that is being borrowed from
+     * @return WAMPL balance that was wrapped. Equal to loanRouter allowance for WAMPL.
+     */
+    function _wamplWrap(uint256 underlyingAmount, IBondController bond) internal returns (uint256) {
+        // Confirm that AMPL was sent
+        require(underlyingAmount > 0, "WamplLoanRouter: No AMPL supplied");
+
+        // Confirm that bond's collateral has WAMPL as underlying
+        IButtonWrapper wrapper = IButtonWrapper(bond.collateralToken());
+        require(wrapper.underlying() == address(wampl), "Collateral Token underlying does not match WAMPL address.");
+
+        // Transferring AMPL to contract
+        SafeERC20.safeTransferFrom(wampl, msg.sender, address(this), underlyingAmount);
+
+        // Wrapping contract's balance of AMPL into WAMPL
+        wampl.deposit(underlyingAmount);
+
+        // Approve loanRouter to take wampl
+        uint256 wamplBalance = wampl.balanceOf(address(this));
+        wampl.approve(address(loanRouter), wamplBalance);
+        return wamplBalance;
+    }
+
+    /**
+     * @dev Distributes tranche balances and borrowed amounts to end-user
+     * @param amountOut The output amount that is being borrowed
+     * @param bond The bond that is being borrowed from
+     * @param currency The asset being borrowed
+     */
+    function _distributeLoanOutput(
+        uint256 amountOut,
+        IBondController bond,
+        IERC20 currency
+    ) internal {
+        // Send loan currenncy out from this contract to msg.sender
+        SafeERC20.safeTransfer(currency, msg.sender, amountOut);
+
+        // Send out the tranche tokens from this contract to the msg.sender
+        ITranche tranche;
+        for (uint256 i = 0; i < bond.trancheCount(); i++) {
+            (tranche, ) = bond.tranches(i);
+            SafeERC20.safeTransfer(tranche, msg.sender, tranche.balanceOf(address(this)));
+        }
+    }
+}

--- a/contracts/WamplLoanRouter.sol
+++ b/contracts/WamplLoanRouter.sol
@@ -41,10 +41,10 @@ contract WamplLoanRouter is IWamplLoanRouter {
         uint256 minOutput
     ) external override returns (uint256 amountOut) {
         uint256 wamplBalance = _wamplWrapAndApprove(amplAmount);
-        uint256 loanAmountOut = loanRouter.wrapAndBorrow(wamplBalance, bond, currency, sales, minOutput);
-        require(loanAmountOut >= minOutput, "WamplLoanRouter: Insufficient output");
-        _distributeLoanOutput(loanAmountOut, bond, currency);
-        return loanAmountOut;
+        amountOut = loanRouter.wrapAndBorrow(wamplBalance, bond, currency, sales, minOutput);
+        require(amountOut >= minOutput, "WamplLoanRouter: Insufficient output");
+        _distributeLoanOutput(amountOut, bond, currency);
+        return amountOut;
     }
 
     /**
@@ -57,10 +57,10 @@ contract WamplLoanRouter is IWamplLoanRouter {
         uint256 minOutput
     ) external override returns (uint256 amountOut) {
         uint256 wamplBalance = _wamplWrapAndApprove(amplAmount);
-        uint256 loanAmountOut = loanRouter.wrapAndBorrowMax(wamplBalance, bond, currency, minOutput);
-        require(loanAmountOut >= minOutput, "WamplLoanRouter: Insufficient output");
-        _distributeLoanOutput(loanAmountOut, bond, currency);
-        return loanAmountOut;
+        amountOut = loanRouter.wrapAndBorrowMax(wamplBalance, bond, currency, minOutput);
+        require(amountOut >= minOutput, "WamplLoanRouter: Insufficient output");
+        _distributeLoanOutput(amountOut, bond, currency);
+        return amountOut;
     }
 
     /**

--- a/contracts/WethLoanRouter.sol
+++ b/contracts/WethLoanRouter.sol
@@ -37,10 +37,10 @@ contract WethLoanRouter is IWethLoanRouter {
         uint256 minOutput
     ) external payable override returns (uint256 amountOut) {
         uint256 wethBalance = _wethWrapAndApprove();
-        uint256 loanAmountOut = loanRouter.wrapAndBorrow(wethBalance, bond, currency, sales, minOutput);
-        require(loanAmountOut >= minOutput, "WethLoanRouter: Insufficient output");
-        _distributeLoanOutput(loanAmountOut, bond, currency);
-        return loanAmountOut;
+        amountOut = loanRouter.wrapAndBorrow(wethBalance, bond, currency, sales, minOutput);
+        require(amountOut >= minOutput, "WethLoanRouter: Insufficient output");
+        _distributeLoanOutput(amountOut, bond, currency);
+        return amountOut;
     }
 
     /**
@@ -52,10 +52,10 @@ contract WethLoanRouter is IWethLoanRouter {
         uint256 minOutput
     ) external payable override returns (uint256 amountOut) {
         uint256 wethBalance = _wethWrapAndApprove();
-        uint256 loanAmountOut = loanRouter.wrapAndBorrowMax(wethBalance, bond, currency, minOutput);
-        require(loanAmountOut >= minOutput, "WethLoanRouter: Insufficient output");
-        _distributeLoanOutput(loanAmountOut, bond, currency);
-        return loanAmountOut;
+        amountOut = loanRouter.wrapAndBorrowMax(wethBalance, bond, currency, minOutput);
+        require(amountOut >= minOutput, "WethLoanRouter: Insufficient output");
+        _distributeLoanOutput(amountOut, bond, currency);
+        return amountOut;
     }
 
     /**

--- a/contracts/WethLoanRouter.sol
+++ b/contracts/WethLoanRouter.sol
@@ -7,7 +7,8 @@ import "./interfaces/ITranche.sol";
 import "./interfaces/IButtonWrapper.sol";
 import "./interfaces/IWETH.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
+import "@rari-capital/solmate/src/tokens/ERC20.sol";
 
 /**
  * @dev Weth Loan Router built on top of a LoanRouter of your choosing
@@ -89,13 +90,13 @@ contract WethLoanRouter is IWethLoanRouter {
         IERC20 currency
     ) internal {
         // Send loan currenncy out from this contract to msg.sender
-        SafeERC20.safeTransfer(currency, msg.sender, amountOut);
+        SafeTransferLib.safeTransfer(ERC20(address(currency)), msg.sender, amountOut);
 
         // Send out the tranche tokens from this contract to the msg.sender
         ITranche tranche;
         for (uint256 i = 0; i < bond.trancheCount(); i++) {
             (tranche, ) = bond.tranches(i);
-            SafeERC20.safeTransfer(tranche, msg.sender, tranche.balanceOf(address(this)));
+            SafeTransferLib.safeTransfer(ERC20(address(tranche)), msg.sender, tranche.balanceOf(address(this)));
         }
     }
 }

--- a/contracts/WethLoanRouter.sol
+++ b/contracts/WethLoanRouter.sol
@@ -36,7 +36,7 @@ contract WethLoanRouter is IWethLoanRouter {
         uint256[] memory sales,
         uint256 minOutput
     ) external payable override returns (uint256 amountOut) {
-        uint256 wethBalance = _wethWrapAndApprove(bond);
+        uint256 wethBalance = _wethWrapAndApprove();
         uint256 loanAmountOut = loanRouter.wrapAndBorrow(wethBalance, bond, currency, sales, minOutput);
         require(loanAmountOut >= minOutput, "WethLoanRouter: Insufficient output");
         _distributeLoanOutput(loanAmountOut, bond, currency);
@@ -51,7 +51,7 @@ contract WethLoanRouter is IWethLoanRouter {
         IERC20 currency,
         uint256 minOutput
     ) external payable override returns (uint256 amountOut) {
-        uint256 wethBalance = _wethWrapAndApprove(bond);
+        uint256 wethBalance = _wethWrapAndApprove();
         uint256 loanAmountOut = loanRouter.wrapAndBorrowMax(wethBalance, bond, currency, minOutput);
         require(loanAmountOut >= minOutput, "WethLoanRouter: Insufficient output");
         _distributeLoanOutput(loanAmountOut, bond, currency);
@@ -61,10 +61,9 @@ contract WethLoanRouter is IWethLoanRouter {
     /**
      * @dev Wraps the ETH that was transferred to this contract and then approves loanRouter for entire amount
      * @dev No need to check that bond's collateral has WETH as underlying since deposit will fail otherwise
-     * @param bond The bond that is being borrowed from
      * @return WETH balance that was wrapped. Equal to loanRouter allowance for WETH.
      */
-    function _wethWrapAndApprove(IBondController bond) internal returns (uint256) {
+    function _wethWrapAndApprove() internal returns (uint256) {
         // Confirm that ETH was sent
         uint256 value = msg.value;
         require(value > 0, "ButtonTokenWethRouter: No ETH supplied");

--- a/contracts/WethLoanRouter.sol
+++ b/contracts/WethLoanRouter.sol
@@ -36,7 +36,7 @@ contract WethLoanRouter is IWethLoanRouter {
         uint256[] memory sales,
         uint256 minOutput
     ) external payable override returns (uint256 amountOut) {
-        uint256 wethBalance = _wethWrap(bond);
+        uint256 wethBalance = _wethWrapAndApprove(bond);
         uint256 loanAmountOut = loanRouter.wrapAndBorrow(wethBalance, bond, currency, sales, minOutput);
         require(loanAmountOut >= minOutput, "WethLoanRouter: Insufficient output");
         _distributeLoanOutput(loanAmountOut, bond, currency);
@@ -51,7 +51,7 @@ contract WethLoanRouter is IWethLoanRouter {
         IERC20 currency,
         uint256 minOutput
     ) external payable override returns (uint256 amountOut) {
-        uint256 wethBalance = _wethWrap(bond);
+        uint256 wethBalance = _wethWrapAndApprove(bond);
         uint256 loanAmountOut = loanRouter.wrapAndBorrowMax(wethBalance, bond, currency, minOutput);
         require(loanAmountOut >= minOutput, "WethLoanRouter: Insufficient output");
         _distributeLoanOutput(loanAmountOut, bond, currency);
@@ -64,7 +64,7 @@ contract WethLoanRouter is IWethLoanRouter {
      * @param bond The bond that is being borrowed from
      * @return WETH balance that was wrapped. Equal to loanRouter allowance for WETH.
      */
-    function _wethWrap(IBondController bond) internal returns (uint256) {
+    function _wethWrapAndApprove(IBondController bond) internal returns (uint256) {
         // Confirm that ETH was sent
         uint256 value = msg.value;
         require(value > 0, "ButtonTokenWethRouter: No ETH supplied");

--- a/contracts/interfaces/IWAMPL.sol
+++ b/contracts/interfaces/IWAMPL.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// from https://github.com/buttonwood-protocol/button-wrappers
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// Interface definition for WETH contract, which wraps ETH into an ERC20 token.
+interface IWAMPL is IERC20 {
+    /// @notice Transfers AMPLs from {msg.sender} and mints wAMPLs.
+    ///
+    /// @param amples The amount of AMPLs to deposit.
+    /// @return The amount of wAMPLs minted.
+    function deposit(uint256 amples) external returns (uint256);
+}

--- a/contracts/interfaces/IWAMPL.sol
+++ b/contracts/interfaces/IWAMPL.sol
@@ -11,4 +11,7 @@ interface IWAMPL is IERC20 {
     /// @param amples The amount of AMPLs to deposit.
     /// @return The amount of wAMPLs minted.
     function deposit(uint256 amples) external returns (uint256);
+
+    /// @return The address of the underlying "wrapped" token ie) AMPL.
+    function underlying() external view returns (address);
 }

--- a/contracts/interfaces/IWamplLoanRouter.sol
+++ b/contracts/interfaces/IWamplLoanRouter.sol
@@ -1,0 +1,40 @@
+pragma solidity 0.8.3;
+
+import "./IBondController.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @dev Router for creating loans with tranche
+ */
+interface IWamplLoanRouter {
+    /**
+     * @notice Borrow against a given bond, wrapping the raw ampl collateral into a WAMPL ButtonToken first
+     * @param underlyingAmount The amount of collateral to deposit into the bond
+     * @param bond The bond to borrow from
+     * @param currency The asset to borrow
+     * @param sales The number of tranche tokens to sell, in tranche index order
+     * @param minOutput The minimum amount of currency to get out, reverts if not met
+     */
+    function wrapAndBorrow(
+        uint256 underlyingAmount,
+        IBondController bond,
+        IERC20 currency,
+        uint256[] memory sales,
+        uint256 minOutput
+    ) external payable returns (uint256 amountOut);
+
+    /**
+     * @notice Borrow as much as possible against a given bond,
+     *  wrapping the raw ampl collateral into a WAMPL ButtonToken first
+     * @param underlyingAmount The amount of collateral to deposit into the bond
+     * @param bond The bond to borrow from
+     * @param currency The asset to borrow
+     * @param minOutput The minimum amount of currency to get out, reverts if not met
+     */
+    function wrapAndBorrowMax(
+        uint256 underlyingAmount,
+        IBondController bond,
+        IERC20 currency,
+        uint256 minOutput
+    ) external payable returns (uint256 amountOut);
+}

--- a/contracts/interfaces/IWamplLoanRouter.sol
+++ b/contracts/interfaces/IWamplLoanRouter.sol
@@ -21,7 +21,7 @@ interface IWamplLoanRouter {
         IERC20 currency,
         uint256[] memory sales,
         uint256 minOutput
-    ) external payable returns (uint256 amountOut);
+    ) external returns (uint256 amountOut);
 
     /**
      * @notice Borrow as much as possible against a given bond,
@@ -36,5 +36,5 @@ interface IWamplLoanRouter {
         IBondController bond,
         IERC20 currency,
         uint256 minOutput
-    ) external payable returns (uint256 amountOut);
+    ) external returns (uint256 amountOut);
 }

--- a/contracts/interfaces/IWamplLoanRouter.sol
+++ b/contracts/interfaces/IWamplLoanRouter.sol
@@ -8,15 +8,15 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  */
 interface IWamplLoanRouter {
     /**
-     * @notice Borrow against a given bond, wrapping the raw ampl collateral into a WAMPL ButtonToken first
-     * @param underlyingAmount The amount of collateral to deposit into the bond
+     * @notice Borrow against a given bond, wrapping the raw AMPL collateral into a WAMPL ButtonToken first
+     * @param amplAmount The amount of AMPL to deposit into the bond
      * @param bond The bond to borrow from
      * @param currency The asset to borrow
      * @param sales The number of tranche tokens to sell, in tranche index order
      * @param minOutput The minimum amount of currency to get out, reverts if not met
      */
     function wrapAndBorrow(
-        uint256 underlyingAmount,
+        uint256 amplAmount,
         IBondController bond,
         IERC20 currency,
         uint256[] memory sales,
@@ -26,13 +26,13 @@ interface IWamplLoanRouter {
     /**
      * @notice Borrow as much as possible against a given bond,
      *  wrapping the raw ampl collateral into a WAMPL ButtonToken first
-     * @param underlyingAmount The amount of collateral to deposit into the bond
+     * @param amplAmount The amount of AMPL to deposit into the bond
      * @param bond The bond to borrow from
      * @param currency The asset to borrow
      * @param minOutput The minimum amount of currency to get out, reverts if not met
      */
     function wrapAndBorrowMax(
-        uint256 underlyingAmount,
+        uint256 amplAmount,
         IBondController bond,
         IERC20 currency,
         uint256 minOutput

--- a/contracts/test/BadLoanRouter.sol
+++ b/contracts/test/BadLoanRouter.sol
@@ -1,0 +1,66 @@
+pragma solidity ^0.8.3;
+
+import "../interfaces/ILoanRouter.sol";
+import "../interfaces/IBondController.sol";
+import "../interfaces/ITranche.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @dev Loan router for the UniswapV3 AMM
+ */
+contract BadLoanRouter is ILoanRouter {
+
+    uint256 public constant MAX_UINT256 = type(uint256).max;
+
+    /**
+     * @inheritdoc ILoanRouter
+     */
+    function wrapAndBorrow(
+        uint256 underlyingAmount,
+        IBondController bond,
+        IERC20 currency,
+        uint256[] memory sales,
+        uint256 minOutput
+    ) external override returns (uint256 amountOut) {
+        return minOutput - 1;
+    }
+
+    /**
+     * @inheritdoc ILoanRouter
+     */
+    function wrapAndBorrowMax(
+        uint256 underlyingAmount,
+        IBondController bond,
+        IERC20 currency,
+        uint256 minOutput
+    ) external override returns (uint256 amountOut) {
+        return minOutput - 1;
+    }
+
+    /**
+     * @inheritdoc ILoanRouter
+     */
+    function borrow(
+        uint256 amount,
+        IBondController bond,
+        IERC20 currency,
+        uint256[] memory sales,
+        uint256 minOutput
+    ) external override returns (uint256 amountOut) {
+        return minOutput - 1;
+    }
+
+    /**
+     * @inheritdoc ILoanRouter
+     */
+    function borrowMax(
+        uint256 amount,
+        IBondController bond,
+        IERC20 currency,
+        uint256 minOutput
+    ) external override returns (uint256 amountOut) {
+        return minOutput - 1;
+    }
+}

--- a/contracts/test/BadLoanRouter.sol
+++ b/contracts/test/BadLoanRouter.sol
@@ -8,10 +8,10 @@ import "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
- * @dev Loan router for the UniswapV3 AMM
+ * @dev Purposely Bad Loan router to test failure conditions of Wampl/Weth Loan Routers.
  */
+/* solhint-disable */
 contract BadLoanRouter is ILoanRouter {
-
     uint256 public constant MAX_UINT256 = type(uint256).max;
 
     /**

--- a/contracts/test/WAMPL.sol
+++ b/contracts/test/WAMPL.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.3;
+
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract WAMPL {
+    string public name = "Wrapped Ampl";
+    string public symbol = "WAMPL";
+    uint8 public decimals = 18;
+    uint256 public constant MAX_UINT = type(uint256).max;
+    address public ampl;
+
+    /**
+     * @dev Initializes ERC20 token
+     */
+    constructor(address _ampl) {
+        ampl = _ampl;
+    }
+
+    event Approval(address indexed src, address indexed guy, uint256 wad);
+    event Transfer(address indexed src, address indexed dst, uint256 wad);
+    event Deposit(address indexed dst, uint256 wad);
+    event Withdrawal(address indexed src, uint256 wad);
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function deposit(uint256 amplAmount) external returns (uint256) {
+        SafeERC20.safeTransferFrom(IERC20(ampl), msg.sender, address(this), amplAmount);
+        balanceOf[msg.sender] += amplAmount;
+        emit Deposit(msg.sender, amplAmount);
+        return amplAmount;
+    }
+
+    function withdraw(uint256 amplAmount) public {
+        require(balanceOf[msg.sender] >= amplAmount, "Insufficient balance");
+        balanceOf[msg.sender] -= amplAmount;
+        SafeERC20.safeTransfer(IERC20(ampl), msg.sender, amplAmount);
+        emit Withdrawal(msg.sender, amplAmount);
+    }
+
+    function totalSupply() public view returns (uint256) {
+        return IERC20(ampl).balanceOf(address(this));
+    }
+
+    function approve(address other, uint256 amplAmount) public returns (bool) {
+        allowance[msg.sender][other] = amplAmount;
+        emit Approval(msg.sender, other, amplAmount);
+        return true;
+    }
+
+    function transfer(address dst, uint256 amplAmount) public returns (bool) {
+        return transferFrom(msg.sender, dst, amplAmount);
+    }
+
+    function transferFrom(
+        address src,
+        address dst,
+        uint256 amplAmount
+    ) public returns (bool) {
+        require(balanceOf[src] >= amplAmount, "Insufficient balance");
+
+        if (src != msg.sender && allowance[src][msg.sender] != MAX_UINT) {
+            require(allowance[src][msg.sender] >= amplAmount, "Insufficient allowance");
+            allowance[src][msg.sender] -= amplAmount;
+        }
+
+        balanceOf[src] -= amplAmount;
+        balanceOf[dst] += amplAmount;
+
+        emit Transfer(src, dst, amplAmount);
+
+        return true;
+    }
+
+    function underlying() external view returns (address) {
+        return ampl;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   },
   "dependencies": {
     "@openzeppelin/contracts-upgradeable": "^4.1.0",
+    "@rari-capital/solmate": "^6.4.0",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "@uniswap/v3-periphery": "^1.1.0",
     "lodash": "^4.17.21"

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -392,7 +392,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("481972");
+      expect(gasUsed.toString()).to.equal("481981");
     });
   });
 });

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -392,7 +392,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("481981");
+      expect(gasUsed.toString()).to.equal("481972");
     });
   });
 });

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -125,11 +125,9 @@ describe("WAMPL Loan Router", () => {
       const minOutput = hre.ethers.utils.parseEther("50");
 
       await expect(
-        router
-          .connect(user)
-          .wrapAndBorrowMax(amount, bond.address, mockCashToken.address, minOutput, {
-            gasLimit: 9500000,
-          }),
+        router.connect(user).wrapAndBorrowMax(amount, bond.address, mockCashToken.address, minOutput, {
+          gasLimit: 9500000,
+        }),
       )
         // // Note: the mock wrapper wraps at a 1:1 ratio, thus the wrapped output is equal to the input
         .to.emit(ampl, "Transfer")
@@ -306,9 +304,8 @@ describe("WAMPL Loan Router", () => {
 
   describe("wrapAndBorrow", function () {
     it("should successfully wrap and borrow", async () => {
-      const { router, loanRouter, tranches, ampl, wampl, mockWrapperToken, mockCashToken, bond, user } = await loadFixture(
-        fixture,
-      );
+      const { router, loanRouter, tranches, ampl, wampl, mockWrapperToken, mockCashToken, bond, user } =
+        await loadFixture(fixture);
 
       const userAddress = await user.getAddress();
       const amount = hre.ethers.utils.parseEther("100");

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("759376");
+      expect(gasUsed.toString()).to.equal("759395");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("759334");
+      expect(gasUsed.toString()).to.equal("759376");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -54,7 +54,9 @@ describe("WAMPL Loan Router", () => {
     const wampl = <WAMPL>await deploy("WAMPL", admin, [ampl.address]);
 
     const router = <WamplLoanRouter>await deploy("WamplLoanRouter", admin, [loanRouter.address, wampl.address]);
-    const routerWithBadLoanRouter = <WamplLoanRouter>await deploy("WamplLoanRouter", admin, [badLoanRouter.address, wampl.address]);
+    const routerWithBadLoanRouter = <WamplLoanRouter>(
+      await deploy("WamplLoanRouter", admin, [badLoanRouter.address, wampl.address])
+    );
 
     const mockWrapperToken = <MockButtonWrapper>(
       await deploy("MockButtonWrapper", admin, [wampl.address, "Mock Button WAMPL", "MOCK-BTN-WAMPL"])
@@ -671,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("759338");
+      expect(gasUsed.toString()).to.equal("759334");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -628,7 +628,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("763396");
+      expect(gasUsed.toString()).to.equal("760923");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -320,7 +320,7 @@ describe("WAMPL Loan Router", () => {
           .wrapAndBorrowMax(amount, bond.address, mockCashToken.address, hre.ethers.utils.parseEther("50"), {
             gasLimit: 9500000,
           }),
-      ).to.be.revertedWith("ERC20: insufficient allowance");
+      ).to.be.revertedWith("TRANSFER_FROM_FAILED");
     });
   });
 
@@ -647,7 +647,7 @@ describe("WAMPL Loan Router", () => {
             hre.ethers.utils.parseEther("50"),
             { gasLimit: 9500000 },
           ),
-      ).to.be.revertedWith("ERC20: insufficient allowance");
+      ).to.be.revertedWith("TRANSFER_FROM_FAILED");
     });
 
     it("gas [ @skip-on-coverage ]", async () => {
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("759395");
+      expect(gasUsed.toString()).to.equal("754318");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -51,7 +51,9 @@ describe("WETH Loan Router", () => {
 
     const weth = <WETH9>await deploy("WETH9", admin, []);
     const router = <WethLoanRouter>await deploy("WethLoanRouter", admin, [loanRouter.address, weth.address]);
-    const routerWithBadLoanRouter = <WethLoanRouter>await deploy("WethLoanRouter", admin, [badLoanRouter.address, weth.address]);
+    const routerWithBadLoanRouter = <WethLoanRouter>(
+      await deploy("WethLoanRouter", admin, [badLoanRouter.address, weth.address])
+    );
 
     const mockWrapperToken = <MockButtonWrapper>(
       await deploy("MockButtonWrapper", admin, [weth.address, "Mock Button WETH", "MOCK-BTN-WETH"])
@@ -274,10 +276,12 @@ describe("WETH Loan Router", () => {
 
     // min output of 50 will not be enough because the badLoanRouter will output 0
     await expect(
-      routerWithBadLoanRouter.connect(user).wrapAndBorrowMax(bond.address, mockCashToken.address, hre.ethers.utils.parseEther("50"), {
-        value: amount,
-        gasLimit: 9500000,
-      }),
+      routerWithBadLoanRouter
+        .connect(user)
+        .wrapAndBorrowMax(bond.address, mockCashToken.address, hre.ethers.utils.parseEther("50"), {
+          value: amount,
+          gasLimit: 9500000,
+        }),
     ).to.be.revertedWith("WethLoanRouter: Insufficient output");
   });
 
@@ -574,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("686776");
+      expect(gasUsed.toString()).to.equal("686772");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("686766");
+      expect(gasUsed.toString()).to.equal("682820");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("686772");
+      expect(gasUsed.toString()).to.equal("686766");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,6 +885,11 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
   integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
 
+"@rari-capital/solmate@^6.4.0":
+  version "6.4.0"
+  resolved "https://npm.buttonwood.dev/@rari-capital%2fsolmate/-/solmate-6.4.0.tgz#c6ee4110c8075f14b415e420b13bd8bdbbc93d9e"
+  integrity sha512-BXWIHHbG5Zbgrxi0qVYe0Zs+bfx+XgOciVUACjuIApV0KzC0kY8XdO1higusIei/ZKCC+GUKdcdQZflxYPUTKQ==
+
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@resolver-engine/core/-/core-0.3.3.tgz#590f77d85d45bc7ecc4e06c654f41345db6ca967"


### PR DESCRIPTION
## Changes:
- Created `WamplLoanRouter`
- Also updating `WethLoanRouter` to get rid of redundant checks
- Also updating `WethLoanRouter` to validate minOutput instead of just trusting underlying LoanRouter
- https://prometheuslabs.atlassian.net/browse/PROM-281?atlOrigin=eyJpIjoiZjJiMTdlZjNmZjZhNGY3ZDg3YWU2OTE1NzdiYmE5NzIiLCJwIjoiaiJ9

## Tests:
- [x] Added testing by using a mock WAMPL contract was one-to-one with a mock AMPL that utilized a MockERC20 contract.

## Reviewers:
@DRC9702 
@aalavandhan 
@marktoda 
@Fiddlekins 