### PR TITLE
fix(iweth/iwampl): adding burn/withdraw methods to interfaces

### DIFF
--- a/contracts/WethLoanRouter.sol
+++ b/contracts/WethLoanRouter.sol
@@ -5,7 +5,7 @@ import "./interfaces/ILoanRouter.sol";
 import "./interfaces/IBondController.sol";
 import "./interfaces/ITranche.sol";
 import "./interfaces/IButtonWrapper.sol";
-import "./interfaces/IWETH.sol";
+import "./interfaces/IWETH9.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
 import "@rari-capital/solmate/src/tokens/ERC20.sol";

--- a/contracts/interfaces/IWAMPL.sol
+++ b/contracts/interfaces/IWAMPL.sol
@@ -1,16 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// from https://github.com/buttonwood-protocol/button-wrappers
+// derived from https://github.com/ampleforth/ampleforth-contracts
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-// Interface definition for WETH contract, which wraps ETH into an ERC20 token.
+// Interface definition for WAMPL contract, A fixed-balance ERC-20 wrapper for the AMPL rebasing token.
 interface IWAMPL is IERC20 {
     /// @notice Transfers AMPLs from {msg.sender} and mints wAMPLs.
     ///
     /// @param amples The amount of AMPLs to deposit.
     /// @return The amount of wAMPLs minted.
     function deposit(uint256 amples) external returns (uint256);
+
+    /// @notice Burns wAMPLs from {msg.sender} and transfers AMPLs back.
+    ///
+    /// @param wamples The amount of wAMPLs to burn.
+    /// @return The amount of AMPLs withdrawn.
+    function burn(uint256 wamples) external returns (uint256);
 
     /// @return The address of the underlying "wrapped" token ie) AMPL.
     function underlying() external view returns (address);

--- a/contracts/interfaces/IWETH9.sol
+++ b/contracts/interfaces/IWETH9.sol
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// from https://github.com/buttonwood-protocol/button-wrappers
+// derived from https://github.com/gnosis/canonical-weth/
 
 // Interface definition for WETH contract, which wraps ETH into an ERC20 token.
 interface IWETH9 {
     function deposit() external payable;
+
+    function withdraw(uint wad) external;
 
     function balanceOf(address) external view returns (uint256);
 

--- a/contracts/interfaces/IWETH9.sol
+++ b/contracts/interfaces/IWETH9.sol
@@ -5,7 +5,7 @@
 interface IWETH9 {
     function deposit() external payable;
 
-    function withdraw(uint wad) external;
+    function withdraw(uint256 wad) external;
 
     function balanceOf(address) external view returns (uint256);
 

--- a/contracts/test/WAMPL.sol
+++ b/contracts/test/WAMPL.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.3;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
+// @title Test contract that wraps AMPL 1-to-1
 contract WAMPL {
     string public name = "Wrapped Ampl";
     string public symbol = "WAMPL";
@@ -37,6 +38,10 @@ contract WAMPL {
         balanceOf[msg.sender] -= amplAmount;
         SafeERC20.safeTransfer(IERC20(ampl), msg.sender, amplAmount);
         emit Withdrawal(msg.sender, amplAmount);
+    }
+
+    function burn(uint256 wamples) public {
+        return withdraw(wamples);
     }
 
     function totalSupply() public view returns (uint256) {


### PR DESCRIPTION
## Changes:
- Adding burn/withdraw methods to interfaces (we use these interfaces to generate the ABIs that generate the typechain types for the front-end clients)
- We need these methods in the interfaces (but not the contracts) because they're used for wethUnwrap and wamplUnwrap

## Reviewers:
@Fiddlekins 