### PR TITLE
feat(iwampl): adding wrapper-to-underlying function to iwampl interface

### DIFF
--- a/contracts/interfaces/IWAMPL.sol
+++ b/contracts/interfaces/IWAMPL.sol
@@ -20,4 +20,8 @@ interface IWAMPL is IERC20 {
 
     /// @return The address of the underlying "wrapped" token ie) AMPL.
     function underlying() external view returns (address);
+
+    /// @param wamples The amount of wAMPL tokens.
+    /// @return The amount of AMPL tokens exchangeable.
+    function wrapperToUnderlying(uint256 wamples) external view returns (uint256);
 }

--- a/contracts/test/WAMPL.sol
+++ b/contracts/test/WAMPL.sol
@@ -81,4 +81,8 @@ contract WAMPL {
     function underlying() external view returns (address) {
         return ampl;
     }
+
+    function wrapperToUnderlying(uint256 wamples) external view returns (uint256) {
+        return wamples;
+    }
 }

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("754318");
+      expect(gasUsed.toString()).to.equal("754418");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),


### PR DESCRIPTION
## Changes:
- Adding `wrapperToUnderlying` function to the IWAMPL interface since this is how typechain types are generated for use in the clients

## Reviewers:
@Fiddlekins 