### PR TITLE
 feat(bond-controller): adding virtual scaled collateral balance tracking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x]
-        os: [macOS-latest, windows-latest, ubuntu-latest]
+        os: [ubuntu-latest]
 
     steps:
       - name: Setup Repo
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node-version }} # tests across multiple Deno versions
 
       - name: Install
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Lint
         run: yarn lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
         os: [macOS-latest, windows-latest, ubuntu-latest]
 
     steps:

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -350,7 +350,7 @@ contract BondController is IBondController, OwnableUpgradeable {
                 collateralBalance,
                 scaledCollateralBalance
             );
-            TransferHelper.safeTransfer(collateralToken, _msgSender(), extraneousCollateral);
+            TransferHelper.safeTransfer(collateralToken, owner(), extraneousCollateral);
             lastScaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
         }
     }

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -178,6 +178,7 @@ contract BondController is IBondController, OwnableUpgradeable {
         uint256 virtualCollateralBalance = (scaledCollateralBalance > 0)
             ? Math.mulDiv(lastScaledCollateralBalance, collateralBalance, scaledCollateralBalance)
             : 0;
+        uint256 leftOverCollateral = collateralBalance - virtualCollateralBalance;
 
         // Go through all tranches A-Y (not Z) delivering collateral if possible
         for (uint256 i = 0; i < _tranches.length - 1 && virtualCollateralBalance > 0; i++) {
@@ -200,6 +201,12 @@ contract BondController is IBondController, OwnableUpgradeable {
             _tranche.redeem(address(this), owner(), IERC20(_tranche).balanceOf(address(this)));
         }
 
+        // Transfer any leftover collateral to the owner
+        if (leftOverCollateral > 0) {
+            TransferHelper.safeTransfer(collateralToken, owner(), leftOverCollateral);
+        }
+
+        // All deposited collateral has been paid out
         lastScaledCollateralBalance = 0;
 
         emit Mature(_msgSender());

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -112,7 +112,7 @@ contract BondController is IBondController, OwnableUpgradeable {
 
         uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
         uint256 virtualCollateralBalance = (scaledCollateralBalance > lastScaledCollateralBalance)
-            ? Math.mulDiv(collateralBalance, lastScaledCollateralBalance, scaledCollateralBalance)
+            ? Math.mulDiv(lastScaledCollateralBalance, collateralBalance, scaledCollateralBalance)
             : collateralBalance;
 
         require(
@@ -176,7 +176,7 @@ contract BondController is IBondController, OwnableUpgradeable {
         uint256 scaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
         uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
         uint256 virtualCollateralBalance = (scaledCollateralBalance > 0)
-            ? Math.mulDiv(collateralBalance, lastScaledCollateralBalance, scaledCollateralBalance)
+            ? Math.mulDiv(lastScaledCollateralBalance, collateralBalance, scaledCollateralBalance)
             : 0;
 
         // Go through all tranches A-Y (not Z) delivering collateral if possible
@@ -240,13 +240,13 @@ contract BondController is IBondController, OwnableUpgradeable {
         }
 
         uint256 scaledCollateralBalancePre = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
-        uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
+        uint256 collateralBalancePre = IERC20(collateralToken).balanceOf(address(this));
         uint256 virtualCollateralBalance = (scaledCollateralBalancePre > 0)
-            ? Math.mulDiv(collateralBalance, lastScaledCollateralBalance, scaledCollateralBalancePre)
+            ? Math.mulDiv(lastScaledCollateralBalance, collateralBalancePre, scaledCollateralBalancePre)
             : 0;
 
         // return as a proportion of the total debt redeemed
-        uint256 returnAmount = Math.mulDiv(total, virtualCollateralBalance, totalDebt);
+        uint256 returnAmount = Math.mulDiv(virtualCollateralBalance, total, totalDebt);
 
         totalDebt -= total;
         TransferHelper.safeTransfer(collateralToken, _msgSender(), returnAmount);
@@ -333,7 +333,7 @@ contract BondController is IBondController, OwnableUpgradeable {
 
         return
             (scaledCollateralBalance > lastScaledCollateralBalance)
-                ? Math.mulDiv(collateralBalance, lastScaledCollateralBalance, scaledCollateralBalance)
+                ? Math.mulDiv(lastScaledCollateralBalance, collateralBalance, scaledCollateralBalance)
                 : collateralBalance;
     }
 
@@ -346,8 +346,8 @@ contract BondController is IBondController, OwnableUpgradeable {
         if (scaledExtraneousCollateral > 0) {
             uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
             uint256 extraneousCollateral = Math.mulDiv(
-                collateralBalance,
                 scaledExtraneousCollateral,
+                collateralBalance,
                 scaledCollateralBalance
             );
             TransferHelper.safeTransfer(collateralToken, _msgSender(), extraneousCollateral);

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -111,7 +111,7 @@ contract BondController is IBondController, OwnableUpgradeable {
         uint256 scaledExtraneousCollateral = scaledCollateralBalance - lastScaledCollateralBalance;
 
         uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
-        uint256 virtualCollateralBalance = (scaledCollateralBalance > lastScaledCollateralBalance)
+        uint256 virtualCollateralBalance = (scaledExtraneousCollateral > 0)
             ? Math.mulDiv(lastScaledCollateralBalance, collateralBalance, scaledCollateralBalance)
             : collateralBalance;
 

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -140,7 +140,7 @@ contract BondController is IBondController, OwnableUpgradeable {
             // note: if totalDebt == 0 then we're minting for the first time
             // so shouldn't scale even if there is some collateral mistakenly sent in
             if (collateralBalance > 0 && totalDebt > 0) {
-                trancheValue = (trancheValue * totalDebt) / collateralBalance;
+                trancheValue = Math.mulDiv(trancheValue, totalDebt, collateralBalance);
             }
             newDebt += trancheValue;
             trancheValues[i] = trancheValue;
@@ -236,7 +236,7 @@ contract BondController is IBondController, OwnableUpgradeable {
 
         uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
         // return as a proportion of the total debt redeemed
-        uint256 returnAmount = (total * collateralBalance) / totalDebt;
+        uint256 returnAmount = Math.mulDiv(total, collateralBalance, totalDebt);
 
         totalDebt -= total;
         TransferHelper.safeTransfer(collateralToken, _msgSender(), returnAmount);

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -342,15 +342,10 @@ contract BondController is IBondController, OwnableUpgradeable {
      */
     function withdrawExtraneousCollateral() external onlyOwner {
         uint256 scaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
-        uint256 scaledExtraneousCollateral = scaledCollateralBalance - lastScaledCollateralBalance;
-        if (scaledExtraneousCollateral > 0) {
+        if (scaledCollateralBalance > lastScaledCollateralBalance) {
             uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
-            uint256 extraneousCollateral = Math.mulDiv(
-                scaledExtraneousCollateral,
-                collateralBalance,
-                scaledCollateralBalance
-            );
-            TransferHelper.safeTransfer(collateralToken, owner(), extraneousCollateral);
+            uint256 virtualCollateralBalance = Math.mulDiv(lastScaledCollateralBalance, collateralBalance, scaledCollateralBalance);
+            TransferHelper.safeTransfer(collateralToken, owner(), collateralBalance - virtualCollateralBalance);
             lastScaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
         }
     }

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -98,9 +98,9 @@ contract BondController is IBondController, OwnableUpgradeable {
     }
 
     /**
-     * @dev Withdraw extraneous collateral that was incorrectly sent to the contract
+     * @dev Skims extraneous collateral that was incorrectly sent to the contract
      */
-    modifier withdrawExtraneous() {
+    modifier onSkim() {
         uint256 scaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
         // If there is extraneous collateral, transfer to the owner
         if (scaledCollateralBalance > lastScaledCollateralBalance) {
@@ -120,7 +120,7 @@ contract BondController is IBondController, OwnableUpgradeable {
     /**
      * @inheritdoc IBondController
      */
-    function deposit(uint256 amount) external override withdrawExtraneous {
+    function deposit(uint256 amount) external override onSkim {
         require(amount > 0, "BondController: invalid amount");
 
         require(!isMature, "BondController: Already mature");
@@ -169,7 +169,7 @@ contract BondController is IBondController, OwnableUpgradeable {
     /**
      * @inheritdoc IBondController
      */
-    function mature() external override withdrawExtraneous {
+    function mature() external override onSkim {
         require(!isMature, "BondController: Already mature");
         require(owner() == _msgSender() || maturityDate < block.timestamp, "BondController: Invalid call to mature");
         isMature = true;
@@ -215,7 +215,7 @@ contract BondController is IBondController, OwnableUpgradeable {
     /**
      * @inheritdoc IBondController
      */
-    function redeem(uint256[] memory amounts) external override withdrawExtraneous {
+    function redeem(uint256[] memory amounts) external override onSkim {
         require(!isMature, "BondController: Bond is already mature");
 
         TrancheData[] memory _tranches = tranches;

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -98,8 +98,8 @@ contract BondController is IBondController, OwnableUpgradeable {
     }
 
     /**
-    * @dev Withdraw extraneous collateral that was incorrectly sent to the contract
-    */
+     * @dev Withdraw extraneous collateral that was incorrectly sent to the contract
+     */
     modifier withdrawExtraneous() {
         uint256 scaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
         // If there is extraneous collateral, transfer to the owner
@@ -123,8 +123,6 @@ contract BondController is IBondController, OwnableUpgradeable {
     function deposit(uint256 amount) external override withdrawExtraneous {
         require(amount > 0, "BondController: invalid amount");
 
-        // saving totalDebt in memory to minimize sloads
-        uint256 _totalDebt = totalDebt;
         require(!isMature, "BondController: Already mature");
 
         uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
@@ -141,8 +139,8 @@ contract BondController is IBondController, OwnableUpgradeable {
             // if there is any collateral, we should scale by the debt:collateral ratio
             // note: if totalDebt == 0 then we're minting for the first time
             // so shouldn't scale even if there is some collateral mistakenly sent in
-            if (collateralBalance > 0 && _totalDebt > 0) {
-                trancheValue = (trancheValue * _totalDebt) / collateralBalance;
+            if (collateralBalance > 0 && totalDebt > 0) {
+                trancheValue = (trancheValue * totalDebt) / collateralBalance;
             }
             newDebt += trancheValue;
             trancheValues[i] = trancheValue;
@@ -171,7 +169,7 @@ contract BondController is IBondController, OwnableUpgradeable {
     /**
      * @inheritdoc IBondController
      */
-    function mature() external override withdrawExtraneous{
+    function mature() external override withdrawExtraneous {
         require(!isMature, "BondController: Already mature");
         require(owner() == _msgSender() || maturityDate < block.timestamp, "BondController: Invalid call to mature");
         isMature = true;

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -102,6 +102,7 @@ contract BondController is IBondController, OwnableUpgradeable {
     */
     modifier withdrawExtraneous() {
         uint256 scaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
+        // If there is extraneous collateral, transfer to the owner
         if (scaledCollateralBalance > lastScaledCollateralBalance) {
             uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
             uint256 virtualCollateralBalance = Math.mulDiv(
@@ -110,9 +111,9 @@ contract BondController is IBondController, OwnableUpgradeable {
                 scaledCollateralBalance
             );
             TransferHelper.safeTransfer(collateralToken, owner(), collateralBalance - virtualCollateralBalance);
-            lastScaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
         }
         _;
+        // Update the lastScaledCollateralBalance after the function call
         lastScaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
     }
 

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -324,16 +324,17 @@ contract BondController is IBondController, OwnableUpgradeable {
     }
 
     /**
-    * @dev Get the virtual collateral balance of the bond
-    * @return the virtual collateral balance
-    */
+     * @dev Get the virtual collateral balance of the bond
+     * @return the virtual collateral balance
+     */
     function virtualCollateralBalance() external view returns (uint256) {
         uint256 scaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
         uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
 
-        return (scaledCollateralBalance > lastScaledCollateralBalance)
-        ? Math.mulDiv(collateralBalance, lastScaledCollateralBalance, scaledCollateralBalance)
-        : collateralBalance;
+        return
+            (scaledCollateralBalance > lastScaledCollateralBalance)
+                ? Math.mulDiv(collateralBalance, lastScaledCollateralBalance, scaledCollateralBalance)
+                : collateralBalance;
     }
 
     /**

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -115,7 +115,10 @@ contract BondController is IBondController, OwnableUpgradeable {
             ? Math.mulDiv(collateralBalance, lastScaledCollateralBalance, scaledCollateralBalance)
             : collateralBalance;
 
-        require(depositLimit == 0 || virtualCollateralBalance + amount <= depositLimit, "BondController: Deposit limit");
+        require(
+            depositLimit == 0 || virtualCollateralBalance + amount <= depositLimit,
+            "BondController: Deposit limit"
+        );
 
         TrancheData[] memory _tranches = tranches;
 
@@ -173,8 +176,8 @@ contract BondController is IBondController, OwnableUpgradeable {
         uint256 scaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
         uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
         uint256 virtualCollateralBalance = (scaledCollateralBalance > 0)
-        ? Math.mulDiv(collateralBalance, lastScaledCollateralBalance, scaledCollateralBalance)
-        : 0;
+            ? Math.mulDiv(collateralBalance, lastScaledCollateralBalance, scaledCollateralBalance)
+            : 0;
 
         // Go through all tranches A-Y (not Z) delivering collateral if possible
         for (uint256 i = 0; i < _tranches.length - 1 && virtualCollateralBalance > 0; i++) {
@@ -239,8 +242,8 @@ contract BondController is IBondController, OwnableUpgradeable {
         uint256 scaledCollateralBalancePre = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
         uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
         uint256 virtualCollateralBalance = (scaledCollateralBalancePre > 0)
-        ? Math.mulDiv(collateralBalance, lastScaledCollateralBalance, scaledCollateralBalancePre)
-        : 0;
+            ? Math.mulDiv(collateralBalance, lastScaledCollateralBalance, scaledCollateralBalancePre)
+            : 0;
 
         // return as a proportion of the total debt redeemed
         uint256 returnAmount = Math.mulDiv(total, virtualCollateralBalance, totalDebt);
@@ -328,7 +331,11 @@ contract BondController is IBondController, OwnableUpgradeable {
         uint256 scaledExtraneousCollateral = scaledCollateralBalance - lastScaledCollateralBalance;
         if (scaledExtraneousCollateral > 0) {
             uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
-            uint256 extraneousCollateral = Math.mulDiv(collateralBalance, scaledExtraneousCollateral, scaledCollateralBalance);
+            uint256 extraneousCollateral = Math.mulDiv(
+                collateralBalance,
+                scaledExtraneousCollateral,
+                scaledCollateralBalance
+            );
             TransferHelper.safeTransfer(collateralToken, _msgSender(), extraneousCollateral);
             lastScaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
         }

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -123,13 +123,13 @@ contract BondController is IBondController, OwnableUpgradeable {
         uint256[] memory trancheValues = new uint256[](trancheCount);
         for (uint256 i = 0; i < _tranches.length; i++) {
             // NOTE: solidity 0.8 checks for over/underflow natively so no need for SafeMath
-            uint256 trancheValue = (amount * _tranches[i].ratio) / TRANCHE_RATIO_GRANULARITY;
+            uint256 trancheValue = Math.mulDiv(amount, _tranches[i].ratio, TRANCHE_RATIO_GRANULARITY);
 
             // if there is any collateral, we should scale by the debt:collateral ratio
             // note: if totalDebt == 0 then we're minting for the first time
             // so shouldn't scale even if there is some collateral mistakenly sent in
             if (virtualCollateralBalance > 0 && _totalDebt > 0) {
-                trancheValue = (trancheValue * _totalDebt) / virtualCollateralBalance;
+                trancheValue = Math.mulDiv(trancheValue, _totalDebt, virtualCollateralBalance);
             }
             newDebt += trancheValue;
             trancheValues[i] = trancheValue;
@@ -243,7 +243,7 @@ contract BondController is IBondController, OwnableUpgradeable {
         : 0;
 
         // return as a proportion of the total debt redeemed
-        uint256 returnAmount = (total * virtualCollateralBalance) / totalDebt;
+        uint256 returnAmount = Math.mulDiv(total, virtualCollateralBalance, totalDebt);
 
         totalDebt -= total;
         TransferHelper.safeTransfer(collateralToken, _msgSender(), returnAmount);

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -324,6 +324,19 @@ contract BondController is IBondController, OwnableUpgradeable {
     }
 
     /**
+    * @dev Get the virtual collateral balance of the bond
+    * @return the virtual collateral balance
+    */
+    function virtualCollateralBalance() external view returns (uint256) {
+        uint256 scaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
+        uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
+
+        return (scaledCollateralBalance > lastScaledCollateralBalance)
+        ? Math.mulDiv(collateralBalance, lastScaledCollateralBalance, scaledCollateralBalance)
+        : collateralBalance;
+    }
+
+    /**
      * @dev Withdraw extraneous collateral that was incorrectly sent to the contract
      */
     function withdrawExtraneousCollateral() external onlyOwner {

--- a/contracts/BondController.sol
+++ b/contracts/BondController.sol
@@ -357,7 +357,11 @@ contract BondController is IBondController, OwnableUpgradeable {
         uint256 scaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
         if (scaledCollateralBalance > lastScaledCollateralBalance) {
             uint256 collateralBalance = IERC20(collateralToken).balanceOf(address(this));
-            uint256 virtualCollateralBalance = Math.mulDiv(lastScaledCollateralBalance, collateralBalance, scaledCollateralBalance);
+            uint256 virtualCollateralBalance = Math.mulDiv(
+                lastScaledCollateralBalance,
+                collateralBalance,
+                scaledCollateralBalance
+            );
             TransferHelper.safeTransfer(collateralToken, owner(), collateralBalance - virtualCollateralBalance);
             lastScaledCollateralBalance = IRebasingERC20(collateralToken).scaledBalanceOf(address(this));
         }

--- a/contracts/interfaces/IRebasingERC20.sol
+++ b/contracts/interfaces/IRebasingERC20.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+// Interface definition for Rebasing ERC20 tokens which have a "elastic" external
+// balance and "fixed" internal balance. Each user's external balance is
+// represented as a product of a "scalar" and the user's internal balance.
+//
+// From time to time the "Rebase" event updates scaler,
+// which increases/decreases all user balances proportionally.
+//
+// The standard ERC-20 methods are denominated in the elastic balance
+//
+interface IRebasingERC20 is IERC20, IERC20Metadata {
+    /// @notice Returns the fixed balance of the specified address.
+    /// @param who The address to query.
+    function scaledBalanceOf(address who) external view returns (uint256);
+
+    /// @notice Returns the total fixed supply.
+    function scaledTotalSupply() external view returns (uint256);
+
+    /// @notice Transfer all of the sender's balance to a specified address.
+    /// @param to The address to transfer to.
+    /// @return True on success, false otherwise.
+    function transferAll(address to) external returns (bool);
+
+    /// @notice Transfer all balance tokens from one address to another.
+    /// @param from The address to send tokens from.
+    /// @param to The address to transfer to.
+    function transferAllFrom(address from, address to) external returns (bool);
+
+    /// @notice Triggers the next rebase, if applicable.
+    function rebase() external;
+
+    /// @notice Event emitted when the balance scalar is updated.
+    /// @param epoch The number of rebases since inception.
+    /// @param newScalar The new scalar.
+    event Rebase(uint256 indexed epoch, uint256 newScalar);
+}

--- a/contracts/test/Ample.sol
+++ b/contracts/test/Ample.sol
@@ -1,0 +1,1 @@
+import "ampleforth-contracts/contracts/UFragments.sol";

--- a/contracts/test/MockButtonWrapper.sol
+++ b/contracts/test/MockButtonWrapper.sol
@@ -58,4 +58,8 @@ contract MockButtonWrapper is Context, ERC20Burnable, IButtonWrapper {
     function underlying() external view override returns (address) {
         return address(_underlying);
     }
+
+    function scaledBalanceOf(address who) external view returns (uint256) {
+        return super.balanceOf(who);
+    }
 }

--- a/contracts/test/MockButtonWrapper.sol
+++ b/contracts/test/MockButtonWrapper.sol
@@ -3,12 +3,10 @@ pragma solidity ^0.8.0;
 
 import "../interfaces/IButtonWrapper.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "./MockRebasingERC20.sol";
 
-contract MockButtonWrapper is Context, ERC20Burnable, IButtonWrapper {
-    uint256 private constant MULTIPLIER_GRANULARITY = 10000;
-    uint256 public multiplier = 10000;
+contract MockButtonWrapper is Context, MockRebasingERC20, IButtonWrapper {
     IERC20 public _underlying;
 
     /**
@@ -18,48 +16,24 @@ contract MockButtonWrapper is Context, ERC20Burnable, IButtonWrapper {
         IERC20 underlying_,
         string memory name,
         string memory symbol
-    ) ERC20(name, symbol) {
+    ) MockRebasingERC20(name, symbol, IERC20Metadata(address(underlying_)).decimals()) {
         _underlying = underlying_;
     }
 
     /**
      * @inheritdoc IButtonWrapper
-     * @dev Mints 1 for 1
      */
     function deposit(uint256 uAmount) external override returns (uint256) {
         SafeERC20.safeTransferFrom(_underlying, msg.sender, address(this), uAmount);
-        _mint(msg.sender, uAmount);
+        uint256 amount = (uAmount * multiplier) / MULTIPLIER_GRANULARITY;
+        _mint(msg.sender, amount);
         return uAmount;
     }
 
     /**
-     * @dev Creates `amount` new tokens for `to`. Public for any test to call.
-     *
-     * See {ERC20-_mint}.
+     * @inheritdoc IButtonWrapper
      */
-    function mint(address to, uint256 amount) public virtual {
-        _mint(to, amount);
-    }
-
-    function rebase(uint256 _multiplier) external {
-        multiplier = _multiplier;
-    }
-
-    function transfer(address who, uint256 amount) public override returns (bool) {
-        // transfer actual amount with the multiplier divided out, so balances line up
-        return super.transfer(who, (amount * MULTIPLIER_GRANULARITY) / multiplier);
-    }
-
-    function balanceOf(address who) public view override returns (uint256) {
-        // multiply underlying balance to accommodate current rebase multiplier
-        return (super.balanceOf(who) * multiplier) / MULTIPLIER_GRANULARITY;
-    }
-
     function underlying() external view override returns (address) {
         return address(_underlying);
-    }
-
-    function scaledBalanceOf(address who) external view returns (uint256) {
-        return super.balanceOf(who);
     }
 }

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -35,4 +35,8 @@ contract MockERC20 is Context, ERC20Burnable {
         // multiply underlying balance to accommodate current rebase multiplier
         return (super.balanceOf(who) * multiplier) / MULTIPLIER_GRANULARITY;
     }
+
+    function scaledBalanceOf(address who) external view returns (uint256) {
+        return super.balanceOf(who);
+    }
 }

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -5,9 +5,6 @@ import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 
 contract MockERC20 is Context, ERC20Burnable {
-    uint256 private constant MULTIPLIER_GRANULARITY = 10000;
-    uint256 public multiplier = 10000;
-
     /**
      * @dev Initializes ERC20 token
      */
@@ -20,23 +17,5 @@ contract MockERC20 is Context, ERC20Burnable {
      */
     function mint(address to, uint256 amount) public virtual {
         _mint(to, amount);
-    }
-
-    function rebase(uint256 _multiplier) external {
-        multiplier = _multiplier;
-    }
-
-    function transfer(address who, uint256 amount) public override returns (bool) {
-        // transfer actual amount with the multiplier divided out, so balances line up
-        return super.transfer(who, (amount * MULTIPLIER_GRANULARITY) / multiplier);
-    }
-
-    function balanceOf(address who) public view override returns (uint256) {
-        // multiply underlying balance to accommodate current rebase multiplier
-        return (super.balanceOf(who) * multiplier) / MULTIPLIER_GRANULARITY;
-    }
-
-    function scaledBalanceOf(address who) external view returns (uint256) {
-        return super.balanceOf(who);
     }
 }

--- a/contracts/test/MockERC20CustomDecimals.sol
+++ b/contracts/test/MockERC20CustomDecimals.sol
@@ -5,8 +5,6 @@ import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 
 contract MockERC20CustomDecimals is Context, ERC20Burnable {
-    uint256 private constant MULTIPLIER_GRANULARITY = 10000;
-    uint256 public multiplier = 10000;
     uint8 public _decimals;
 
     /**
@@ -27,27 +25,5 @@ contract MockERC20CustomDecimals is Context, ERC20Burnable {
      */
     function mint(address to, uint256 amount) public virtual {
         _mint(to, amount);
-    }
-
-    function rebase(uint256 _multiplier) external {
-        multiplier = _multiplier;
-    }
-
-    function transfer(address who, uint256 amount) public override returns (bool) {
-        // transfer actual amount with the multiplier divided out, so balances line up
-        return super.transfer(who, (amount * MULTIPLIER_GRANULARITY) / multiplier);
-    }
-
-    function balanceOf(address who) public view override returns (uint256) {
-        // multiply underlying balance to accommodate current rebase multiplier
-        return (super.balanceOf(who) * multiplier) / MULTIPLIER_GRANULARITY;
-    }
-
-    function decimals() public view override returns (uint8) {
-        return _decimals;
-    }
-
-    function scaledBalanceOf(address who) external view returns (uint256) {
-        return super.balanceOf(who);
     }
 }

--- a/contracts/test/MockERC20CustomDecimals.sol
+++ b/contracts/test/MockERC20CustomDecimals.sol
@@ -46,4 +46,8 @@ contract MockERC20CustomDecimals is Context, ERC20Burnable {
     function decimals() public view override returns (uint8) {
         return _decimals;
     }
+
+    function scaledBalanceOf(address who) external view returns (uint256) {
+        return super.balanceOf(who);
+    }
 }

--- a/contracts/test/MockRebasingERC20.sol
+++ b/contracts/test/MockRebasingERC20.sol
@@ -14,12 +14,16 @@ contract MockRebasingERC20 is Context, IRebasingERC20 {
 
     string private _name;
     string private _symbol;
-    uint8 _decimals;
+    uint8 private _decimals;
 
     uint256 internal constant MULTIPLIER_GRANULARITY = 10000;
     uint256 public multiplier = 10000;
 
-    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_
+    ) {
         _name = name_;
         _symbol = symbol_;
         _decimals = decimals_;
@@ -171,9 +175,9 @@ contract MockRebasingERC20 is Context, IRebasingERC20 {
         address owner = _msgSender();
         uint256 currentAllowance = _allowances[owner][spender];
         require(currentAllowance >= subtractedValue, "ERC20: decreased allowance below zero");
-    unchecked {
-        _approve(owner, spender, currentAllowance - subtractedValue);
-    }
+        unchecked {
+            _approve(owner, spender, currentAllowance - subtractedValue);
+        }
 
         return true;
     }
@@ -199,15 +203,15 @@ contract MockRebasingERC20 is Context, IRebasingERC20 {
     ) internal virtual {
         require(from != address(0), "ERC20: transfer from the zero address");
         require(to != address(0), "ERC20: transfer to the zero address");
-        uint256 underlyingAmount =  (amount * MULTIPLIER_GRANULARITY) / multiplier;
+        uint256 underlyingAmount = (amount * MULTIPLIER_GRANULARITY) / multiplier;
 
         _beforeTokenTransfer(from, to, amount);
 
         uint256 fromBalance = _underlyingBalances[from];
         require(fromBalance >= underlyingAmount, "ERC20: transfer amount exceeds balance");
-    unchecked {
-        _underlyingBalances[from] = fromBalance - underlyingAmount;
-    }
+        unchecked {
+            _underlyingBalances[from] = fromBalance - underlyingAmount;
+        }
         _underlyingBalances[to] += underlyingAmount;
 
         emit Transfer(from, to, amount);
@@ -226,7 +230,7 @@ contract MockRebasingERC20 is Context, IRebasingERC20 {
      */
     function _mint(address account, uint256 amount) internal virtual {
         require(account != address(0), "ERC20: mint to the zero address");
-        uint256 underlyingAmount =  (amount * MULTIPLIER_GRANULARITY) / multiplier;
+        uint256 underlyingAmount = (amount * MULTIPLIER_GRANULARITY) / multiplier;
 
         _beforeTokenTransfer(address(0), account, amount);
 
@@ -250,15 +254,15 @@ contract MockRebasingERC20 is Context, IRebasingERC20 {
      */
     function _burn(address account, uint256 amount) internal virtual {
         require(account != address(0), "ERC20: burn from the zero address");
-        uint256 underlyingAmount =  (amount * MULTIPLIER_GRANULARITY) / multiplier;
+        uint256 underlyingAmount = (amount * MULTIPLIER_GRANULARITY) / multiplier;
 
         _beforeTokenTransfer(account, address(0), amount);
 
         uint256 accountBalance = _underlyingBalances[account];
         require(accountBalance >= underlyingAmount, "ERC20: burn amount exceeds balance");
-    unchecked {
-        _underlyingBalances[account] = accountBalance - underlyingAmount;
-    }
+        unchecked {
+            _underlyingBalances[account] = accountBalance - underlyingAmount;
+        }
         _totalUnderlyingSupply -= underlyingAmount;
 
         emit Transfer(account, address(0), amount);
@@ -307,9 +311,9 @@ contract MockRebasingERC20 is Context, IRebasingERC20 {
         uint256 currentAllowance = allowance(owner, spender);
         if (currentAllowance != type(uint256).max) {
             require(currentAllowance >= amount, "ERC20: insufficient allowance");
-        unchecked {
-            _approve(owner, spender, currentAllowance - amount);
-        }
+            unchecked {
+                _approve(owner, spender, currentAllowance - amount);
+            }
         }
     }
 
@@ -360,37 +364,37 @@ contract MockRebasingERC20 is Context, IRebasingERC20 {
     }
 
     /**
-    * @dev See {IRebasingERC20-scaledBalanceOf}.
-    */
-    function scaledBalanceOf(address who) override external view returns (uint256) {
+     * @dev See {IRebasingERC20-scaledBalanceOf}.
+     */
+    function scaledBalanceOf(address who) external view override returns (uint256) {
         return (balanceOf(who) * MULTIPLIER_GRANULARITY) / multiplier;
     }
 
     /**
-    * @dev See {IRebasingERC20-scaledTotalSupply}.
-    */
-    function scaledTotalSupply() override external view returns (uint256) {
+     * @dev See {IRebasingERC20-scaledTotalSupply}.
+     */
+    function scaledTotalSupply() external view override returns (uint256) {
         return (totalSupply() * MULTIPLIER_GRANULARITY) / multiplier;
     }
 
     /**
-    * @dev See {IRebasingERC20-transferAll}.
-    */
-    function transferAll(address to) override external returns (bool) {
+     * @dev See {IRebasingERC20-transferAll}.
+     */
+    function transferAll(address to) external override returns (bool) {
         return transfer(to, balanceOf(msg.sender));
     }
 
     /**
-    * @dev See {IRebasingERC20-transferAllFrom}.
-    */
-    function transferAllFrom(address from, address to) override external returns (bool) {
+     * @dev See {IRebasingERC20-transferAllFrom}.
+     */
+    function transferAllFrom(address from, address to) external override returns (bool) {
         return transferFrom(from, to, allowance(from, msg.sender));
     }
 
     /**
      * @dev See {IRebasingERC20-rebase}.
      */
-    function rebase() override external {
+    function rebase() external override {
         return;
     }
 

--- a/contracts/test/MockRebasingERC20.sol
+++ b/contracts/test/MockRebasingERC20.sol
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import "../interfaces/IRebasingERC20.sol";
+
+contract MockRebasingERC20 is Context, IRebasingERC20 {
+    mapping(address => uint256) private _underlyingBalances;
+
+    mapping(address => mapping(address => uint256)) private _allowances;
+
+    uint256 private _totalUnderlyingSupply;
+
+    string private _name;
+    string private _symbol;
+    uint8 _decimals;
+
+    uint256 internal constant MULTIPLIER_GRANULARITY = 10000;
+    uint256 public multiplier = 10000;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+        _name = name_;
+        _symbol = symbol_;
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view virtual override returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view virtual override returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5.05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless this function is
+     * overridden;
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view virtual override returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalUnderlyingSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return (_underlyingBalances[account] * multiplier) / MULTIPLIER_GRANULARITY;
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `to` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address to, uint256 amount) public virtual override returns (bool) {
+        address owner = _msgSender();
+        _transfer(owner, to, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * NOTE: If `amount` is the maximum `uint256`, the allowance is not updated on
+     * `transferFrom`. This is semantically equivalent to an infinite approval.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        address owner = _msgSender();
+        _approve(owner, spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20}.
+     *
+     * NOTE: Does not update the allowance if the current allowance
+     * is the maximum `uint256`.
+     *
+     * Requirements:
+     *
+     * - `from` and `to` cannot be the zero address.
+     * - `from` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``from``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        address spender = _msgSender();
+        _spendAllowance(from, spender, amount);
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        address owner = _msgSender();
+        _approve(owner, spender, _allowances[owner][spender] + addedValue);
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        address owner = _msgSender();
+        uint256 currentAllowance = _allowances[owner][spender];
+        require(currentAllowance >= subtractedValue, "ERC20: decreased allowance below zero");
+    unchecked {
+        _approve(owner, spender, currentAllowance - subtractedValue);
+    }
+
+        return true;
+    }
+
+    /**
+     * @dev Moves `amount` of tokens from `sender` to `recipient`.
+     *
+     * This internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `from` must have a balance of at least `amount`.
+     */
+    function _transfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual {
+        require(from != address(0), "ERC20: transfer from the zero address");
+        require(to != address(0), "ERC20: transfer to the zero address");
+        uint256 underlyingAmount =  (amount * MULTIPLIER_GRANULARITY) / multiplier;
+
+        _beforeTokenTransfer(from, to, amount);
+
+        uint256 fromBalance = _underlyingBalances[from];
+        require(fromBalance >= underlyingAmount, "ERC20: transfer amount exceeds balance");
+    unchecked {
+        _underlyingBalances[from] = fromBalance - underlyingAmount;
+    }
+        _underlyingBalances[to] += underlyingAmount;
+
+        emit Transfer(from, to, amount);
+
+        _afterTokenTransfer(from, to, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements:
+     *
+     * - `account` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+        uint256 underlyingAmount =  (amount * MULTIPLIER_GRANULARITY) / multiplier;
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalUnderlyingSupply += underlyingAmount;
+        _underlyingBalances[account] += underlyingAmount;
+        emit Transfer(address(0), account, amount);
+
+        _afterTokenTransfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements:
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+        uint256 underlyingAmount =  (amount * MULTIPLIER_GRANULARITY) / multiplier;
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        uint256 accountBalance = _underlyingBalances[account];
+        require(accountBalance >= underlyingAmount, "ERC20: burn amount exceeds balance");
+    unchecked {
+        _underlyingBalances[account] = accountBalance - underlyingAmount;
+    }
+        _totalUnderlyingSupply -= underlyingAmount;
+
+        emit Transfer(account, address(0), amount);
+
+        _afterTokenTransfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner` s tokens.
+     *
+     * This internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Spend `amount` form the allowance of `owner` toward `spender`.
+     *
+     * Does not update the allowance amount in case of infinite allowance.
+     * Revert if not enough allowance is available.
+     *
+     * Might emit an {Approval} event.
+     */
+    function _spendAllowance(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal virtual {
+        uint256 currentAllowance = allowance(owner, spender);
+        if (currentAllowance != type(uint256).max) {
+            require(currentAllowance >= amount, "ERC20: insufficient allowance");
+        unchecked {
+            _approve(owner, spender, currentAllowance - amount);
+        }
+        }
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual {}
+
+    /**
+     * @dev Hook that is called after any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * has been transferred to `to`.
+     * - when `from` is zero, `amount` tokens have been minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens have been burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _afterTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual {}
+
+    /** IRebasingERC20 methods **/
+
+    function setMultiplier(uint256 _multiplier) external {
+        multiplier = _multiplier;
+    }
+
+    /**
+    * @dev See {IRebasingERC20-scaledBalanceOf}.
+    */
+    function scaledBalanceOf(address who) override external view returns (uint256) {
+        return (balanceOf(who) * MULTIPLIER_GRANULARITY) / multiplier;
+    }
+
+    /**
+    * @dev See {IRebasingERC20-scaledTotalSupply}.
+    */
+    function scaledTotalSupply() override external view returns (uint256) {
+        return (totalSupply() * MULTIPLIER_GRANULARITY) / multiplier;
+    }
+
+    /**
+    * @dev See {IRebasingERC20-transferAll}.
+    */
+    function transferAll(address to) override external returns (bool) {
+        return transfer(to, balanceOf(msg.sender));
+    }
+
+    /**
+    * @dev See {IRebasingERC20-transferAllFrom}.
+    */
+    function transferAllFrom(address from, address to) override external returns (bool) {
+        return transferFrom(from, to, allowance(from, msg.sender));
+    }
+
+    /**
+     * @dev See {IRebasingERC20-rebase}.
+     */
+    function rebase() override external {
+        return;
+    }
+
+    /** Mint and burn methods **/
+
+    function mint(address to, uint256 amount) public virtual {
+        _mint(to, amount);
+    }
+
+    function burn(address from, uint256 amount) public virtual {
+        _burn(from, amount);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -92,6 +92,22 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
+        version: "0.7.6",
+        settings: {
+          metadata: {
+            // Not including the metadata hash
+            // https://github.com/paulrberg/solidity-template/issues/31
+            bytecodeHash: "none",
+          },
+          // You should disable the optimizer when debugging
+          // https://hardhat.org/hardhat-network/#solidity-optimizer-support
+          optimizer: {
+            enabled: true,
+            runs: 999999,
+          },
+        },
+      },
+      {
         version: "0.8.3",
         settings: {
           metadata: {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-etherscan": "^2.1.6",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
-    "@openzeppelin/contracts": "^4.4.1",
+    "@openzeppelin/contracts": "^4.8.0",
     "@typechain/ethers-v5": "^5.0.0",
     "@typechain/hardhat": "^1.0.1",
     "@types/chai": "^4.2.13",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
     "@uniswap/lib": "^4.0.1-alpha",
-    "ampleforth-contracts": "https://github.com/ampleforth/ampleforth-contracts.git#v1.2.1",
+    "ampleforth-contracts": "https://github.com/ampleforth/ampleforth-contracts#v1.2.1",
     "chai": "^4.2.0",
     "commitizen": "^4.2.1",
     "cz-conventional-changelog": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
     "@uniswap/lib": "^4.0.1-alpha",
-    "ampleforth-contracts": "https://github.com/ampleforth/ampleforth-contracts#v1.2.1",
+    "ampleforth-contracts": "https://github.com/ampleforth/ampleforth-contracts.git#v1.2.1",
     "chai": "^4.2.0",
     "commitizen": "^4.2.1",
     "cz-conventional-changelog": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
     "@uniswap/lib": "^4.0.1-alpha",
+    "ampleforth-contracts": "https://github.com/ampleforth/ampleforth-contracts#v1.2.1",
     "chai": "^4.2.0",
     "commitizen": "^4.2.1",
     "cz-conventional-changelog": "^3.3.0",

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -704,7 +704,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("226007");
+      expect(gasUsed.toString()).to.equal("226050");
     });
   });
 

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -1469,7 +1469,7 @@ describe("Bond Controller", () => {
   });
 
   describe("Extraneous Collateral", function () {
-    it("No withdrawal to admin when there's no extraneous collateral", async () => {
+    it("No skimming to admin when there's no extraneous collateral", async () => {
       const trancheValues = [200, 300, 500];
       const { bond, mockCollateralToken, user, admin } = await loadFixture(getFixture(trancheValues));
 
@@ -1483,7 +1483,7 @@ describe("Bond Controller", () => {
       expect(await mockCollateralToken.balanceOf(await admin.getAddress())).to.equal(0);
     });
 
-    it("Admin should get extraneous withdrawal when there is (pre-mature) extraneous collateral", async () => {
+    it("Admin should get skim when there is (pre-mature) extraneous collateral", async () => {
       const trancheValues = [200, 300, 500];
       const { bond, mockCollateralToken, user, other, admin } = await loadFixture(getFixture(trancheValues));
 

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -596,7 +596,7 @@ describe("Bond Controller", () => {
       const tx = await bond.connect(user).deposit(amount);
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("297240");
+      expect(gasUsed.toString()).to.equal("297140");
     });
   });
 

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -1426,13 +1426,13 @@ describe("Bond Controller", () => {
   describe("Extraneous Collateral", function () {
     it("Admin should withdraw nothing when there's no extraneous collateral", async () => {
       const trancheValues = [200, 300, 500];
-      const {bond, mockCollateralToken, user, admin} = await loadFixture(getFixture(trancheValues));
+      const { bond, mockCollateralToken, user, admin } = await loadFixture(getFixture(trancheValues));
 
       // User mints 1000 collateral and deposits it
       const amount = parse("1000");
       await mockCollateralToken.mint(await user.getAddress(), amount);
       await mockCollateralToken.connect(user).approve(bond.address, amount);
-      await expect(bond.connect(user).deposit(amount))
+      await expect(bond.connect(user).deposit(amount));
 
       // Admin attempts to withdraw any extraneous collateral
       await expect(bond.connect(admin).withdrawExtraneousCollateral());
@@ -1443,13 +1443,13 @@ describe("Bond Controller", () => {
 
     it("Admin should all extraneous collateral when there's no extraneous collateral", async () => {
       const trancheValues = [200, 300, 500];
-      const {bond, mockCollateralToken, user, other, admin} = await loadFixture(getFixture(trancheValues));
+      const { bond, mockCollateralToken, user, other, admin } = await loadFixture(getFixture(trancheValues));
 
       // User mints 4321 collateral and deposits it
       const amount = parse("4321");
       await mockCollateralToken.mint(await user.getAddress(), amount);
       await mockCollateralToken.connect(user).approve(bond.address, amount);
-      await expect(bond.connect(user).deposit(amount))
+      await expect(bond.connect(user).deposit(amount));
 
       // other mints 1000 collateral and extraneously sends it to the bond
       const extraneousAmount = parse("5678901234");
@@ -1471,13 +1471,13 @@ describe("Bond Controller", () => {
 
   it("Virtual balance matches collateral balance when there are no extraneous deposits", async () => {
     const trancheValues = [200, 300, 500];
-    const {bond, mockCollateralToken, user} = await loadFixture(getFixture(trancheValues));
+    const { bond, mockCollateralToken, user } = await loadFixture(getFixture(trancheValues));
 
     // User mints 1000 collateral and deposits it
     const amount = parse("1000");
     await mockCollateralToken.mint(await user.getAddress(), amount);
     await mockCollateralToken.connect(user).approve(bond.address, amount);
-    await expect(bond.connect(user).deposit(amount))
+    await expect(bond.connect(user).deposit(amount));
 
     // Virtual balance should match collateral balance
     const virtualCollateralBalance = await bond.virtualCollateralBalance();
@@ -1487,13 +1487,13 @@ describe("Bond Controller", () => {
 
   it("Virtual balance equals deposit amounts", async () => {
     const trancheValues = [200, 300, 500];
-    const {bond, mockCollateralToken, user, other} = await loadFixture(getFixture(trancheValues));
+    const { bond, mockCollateralToken, user, other } = await loadFixture(getFixture(trancheValues));
 
     // User mints 4321 collateral and deposits it
     const amount = parse("7799");
     await mockCollateralToken.mint(await user.getAddress(), amount);
     await mockCollateralToken.connect(user).approve(bond.address, amount);
-    await expect(bond.connect(user).deposit(amount))
+    await expect(bond.connect(user).deposit(amount));
 
     // other mints 1000 collateral and extraneously sends it to the bond
     const extraneousAmount = parse("9876");
@@ -1505,7 +1505,6 @@ describe("Bond Controller", () => {
     const collateralBalance = await mockCollateralToken.balanceOf(bond.address);
     expect(virtualCollateralBalance).to.equal(amount);
     expect(virtualCollateralBalance).to.equal(collateralBalance.sub(extraneousAmount));
-
   });
 });
 

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -1367,11 +1367,6 @@ describe("Bond Controller", () => {
       await mockCollateralToken.mint(await userA.getAddress(), amount1k);
       await mockCollateralToken.connect(userA).approve(bond.address, amount1k);
 
-      // Mint extraneous collateral to userB and approve it for bond
-      const extraneousAmount = parse("987656432109876543210");
-      await mockCollateralToken.mint(await userB.getAddress(), extraneousAmount);
-      await mockCollateralToken.connect(userB).approve(bond.address, extraneousAmount);
-
       // UserA deposits 1000 collateral
       await bond.connect(userA).deposit(amount1k);
       // A-token supply is 200, UserA has balance of 200 As
@@ -1384,7 +1379,9 @@ describe("Bond Controller", () => {
       expect(await tranches[2].totalSupply()).to.equal(parse("500"));
       expect(await tranches[2].balanceOf(await userA.getAddress())).to.equal(parse("500"));
 
-      // UserB sends 1000 collateral to the bond without depositing
+      // Mint extraneous collateral to userB who sends it to the bond without depositing
+      const extraneousAmount = parse("987656432109876543210");
+      await mockCollateralToken.mint(await userB.getAddress(), extraneousAmount);
       await mockCollateralToken.connect(userB).transfer(bond.address, extraneousAmount);
 
       // Validating tokens have been transferred
@@ -1441,7 +1438,7 @@ describe("Bond Controller", () => {
       expect(await mockCollateralToken.balanceOf(await admin.getAddress())).to.equal(0);
     });
 
-    it("Admin should all extraneous collateral when there's no extraneous collateral", async () => {
+    it("Admin should withdraw all extraneous collateral when there is extraneous collateral", async () => {
       const trancheValues = [200, 300, 500];
       const { bond, mockCollateralToken, user, other, admin } = await loadFixture(getFixture(trancheValues));
 

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -1,28 +1,21 @@
 import { expect } from "chai";
 import hre, { waffle } from "hardhat";
-import {BigNumber, BigNumberish, Signer} from "ethers";
+import { BigNumber, BigNumberish, Signer } from "ethers";
 import * as _ from "lodash";
 import { Fixture } from "ethereum-waffle";
 import { deploy } from "./utils/contracts";
 import { BlockchainTime } from "./utils/time";
-import {mint, ZERO_ADDRESS} from "./utils/erc20";
+import { ZERO_ADDRESS } from "./utils/erc20";
 const { loadFixture } = waffle;
 
-import {
-  BondController,
-  BondFactory,
-  MockRebasingERC20,
-  Tranche,
-  TrancheFactory,
-  UFragments
-} from "../typechain";
+import { BondController, BondFactory, MockRebasingERC20, Tranche, TrancheFactory, UFragments } from "../typechain";
 const parse = hre.ethers.utils.parseEther;
 const ampleParse = (value: string) => hre.ethers.utils.parseUnits(value, 9);
 const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 const expectEqWithEpsilon = (a: BigNumberish, b: BigNumberish, epsilon: BigNumberish) => {
   expect(BigNumber.from(a).sub(b).abs()).to.be.lte(epsilon);
-}
+};
 
 interface TestContext {
   bond: BondController;
@@ -186,7 +179,9 @@ describe("Bond Controller", () => {
         await deploy("BondFactory", signers[0], [bondImplementation.address, trancheFactory.address])
       );
 
-      const mockCollateralToken = <MockRebasingERC20>await deploy("MockRebasingERC20", signers[0], ["Mock ERC20", "MOCK", 18]);
+      const mockCollateralToken = <MockRebasingERC20>(
+        await deploy("MockRebasingERC20", signers[0], ["Mock ERC20", "MOCK", 18])
+      );
       await expect(
         bondFactory
           .connect(signers[0])
@@ -207,7 +202,9 @@ describe("Bond Controller", () => {
         await deploy("BondFactory", signers[0], [bondImplementation.address, trancheFactory.address])
       );
 
-      const mockCollateralToken = <MockRebasingERC20>await deploy("MockRebasingERC20", signers[0], ["Mock ERC20", "MOCK", 9]);
+      const mockCollateralToken = <MockRebasingERC20>(
+        await deploy("MockRebasingERC20", signers[0], ["Mock ERC20", "MOCK", 9])
+      );
       await expect(
         bondFactory.connect(signers[0]).createBond(mockCollateralToken.address, [], await time.secondsFromNow(10000)),
       ).to.be.revertedWith("BondController: Invalid tranche ratios");
@@ -244,7 +241,9 @@ describe("Bond Controller", () => {
         await deploy("BondFactory", signers[0], [bondImplementation.address, trancheFactory.address])
       );
 
-      const mockCollateralToken = <MockRebasingERC20>await deploy("MockRebasingERC20", signers[0], ["Mock ERC20", "MOCK", 9]);
+      const mockCollateralToken = <MockRebasingERC20>(
+        await deploy("MockRebasingERC20", signers[0], ["Mock ERC20", "MOCK", 9])
+      );
       const maturityDate = await time.secondsFromNow(10000);
       const tx = await bondFactory
         .connect(signers[0])
@@ -411,7 +410,7 @@ describe("Bond Controller", () => {
       expect(await mockCollateralToken.balanceOf(await other.getAddress())).to.equal(parse("500"));
 
       // Other deposits entire balance (half of original minting amount)
-      const halfAmount = parse("500")
+      const halfAmount = parse("500");
       await expect(bond.connect(other).deposit(halfAmount))
         .to.emit(mockCollateralToken, "Transfer")
         .withArgs(await other.getAddress(), bond.address, halfAmount)
@@ -1117,7 +1116,6 @@ describe("Bond Controller", () => {
       // Validating bond has correct collateral and admin has all the extraneous collateral
       expect(await mockCollateralToken.balanceOf(bond.address)).to.equal(0);
       expect(await mockCollateralToken.balanceOf(await admin.getAddress())).to.equal(extraneousAmount);
-
     });
 
     it("should redeemMature correct amounts and leave pre-mature extraneous collateral for admin", async () => {
@@ -1396,7 +1394,7 @@ describe("Bond Controller", () => {
       expect(await bond.totalDebt()).to.equal(amount1k);
 
       // UserA early-redeems all of their A, B, and Z tokens
-      await bond.connect(userA).redeem([parse("200"), parse("300"), parse("500")])
+      await bond.connect(userA).redeem([parse("200"), parse("300"), parse("500")]);
 
       // UserA gets all of their 1000 collateral back
       expect(await mockCollateralToken.balanceOf(await userA.getAddress())).to.equal(amount1k);
@@ -1470,9 +1468,7 @@ describe("Bond Controller: Ampl Stress-Testing", () => {
         .createBondWithDepositLimit(ampl.address, tranches, maturityDate, depositLimit);
       receipt = await tx.wait();
     } else {
-      const tx = await bondFactory
-        .connect(admin)
-        .createBond(ampl.address, tranches, await time.secondsFromNow(10000));
+      const tx = await bondFactory.connect(admin).createBond(ampl.address, tranches, await time.secondsFromNow(10000));
       receipt = await tx.wait();
     }
 
@@ -1522,7 +1518,7 @@ describe("Bond Controller: Ampl Stress-Testing", () => {
       signers: signers.slice(3),
       maturityDate,
       rebase,
-      mint
+      mint,
     };
   };
 
@@ -1539,7 +1535,9 @@ describe("Bond Controller: Ampl Stress-Testing", () => {
 
   it("should successfully deposit collateral and mint tranche tokens", async () => {
     const trancheValues = [200, 300, 500];
-    const { bond, tranches, ampl, userA, userB, userC, admin, mint, rebase } = await loadFixture(getFixture(trancheValues));
+    const { bond, tranches, ampl, userA, userB, userC, admin, mint, rebase } = await loadFixture(
+      getFixture(trancheValues),
+    );
 
     // Mint 1234 AMPL to userA
     await mint(await userA.getAddress(), ampleParse("1234"));
@@ -1552,7 +1550,6 @@ describe("Bond Controller: Ampl Stress-Testing", () => {
     expect(await ampl.balanceOf(await userC.getAddress())).to.equal(ampleParse("5678"));
     expect(await ampl.balanceOf(await admin.getAddress())).to.equal(ampleParse("0"));
     expect(await ampl.balanceOf(bond.address)).to.equal(ampleParse("0"));
-
 
     // userA deposits entire AMPL balance
     await ampl.connect(userA).approve(bond.address, await ampl.connect(userA).balanceOf(await userA.getAddress()));
@@ -1596,14 +1593,12 @@ describe("Bond Controller: Ampl Stress-Testing", () => {
     for (let i = 0; i < tranches.length; i++) {
       const tranche = tranches[i];
       const trancheValue = await tranche.connect(userC).balanceOf(await userC.getAddress());
-      await expect(bond.connect(userC).redeemMature(tranche.address, trancheValue))
+      await expect(bond.connect(userC).redeemMature(tranche.address, trancheValue));
     }
 
     // admin withdraws all extraneous collateral from bond
     await bond.connect(admin).withdrawExtraneousCollateral();
-    const adminAmount = ampleParse("9012.3456").mul(2)
-      .add(ampleParse("7890.1234"))
-      .add(ampleParse("5678.9123"));
+    const adminAmount = ampleParse("9012.3456").mul(2).add(ampleParse("7890.1234")).add(ampleParse("5678.9123"));
 
     // Balance Checks, userA: 1234, userB: ??, userC: 5678, admin: >0, bond: 0
     // Rounded precision to be expected
@@ -1613,6 +1608,4 @@ describe("Bond Controller: Ampl Stress-Testing", () => {
     expect(await ampl.balanceOf(await admin.getAddress())).to.equal(adminAmount);
     expect(await ampl.balanceOf(bond.address)).to.equal(ampleParse("0"));
   });
-
 });
-

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -597,7 +597,7 @@ describe("Bond Controller", () => {
       const tx = await bond.connect(user).deposit(amount);
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("297147");
+      expect(gasUsed.toString()).to.equal("297240");
     });
   });
 
@@ -1421,7 +1421,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("158253");
+      expect(gasUsed.toString()).to.equal("158284");
     });
   });
 });

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -530,13 +530,7 @@ describe("Bond Controller", () => {
 
     it("should successfully mint correct amount of tranche tokens after extraneous transfer", async () => {
       const trancheValues = [200, 300, 500];
-      const {
-        bond,
-        tranches,
-        mockCollateralToken,
-        admin,
-        signers
-      } = await loadFixture(getFixture(trancheValues));
+      const { bond, tranches, mockCollateralToken, admin, signers } = await loadFixture(getFixture(trancheValues));
       const [userA, userB, userC] = signers;
 
       const amount1k = parse("1000");
@@ -584,13 +578,7 @@ describe("Bond Controller", () => {
 
     it("should successfully mint correct amount of tranche tokens with rebases and extraneous transfers", async () => {
       const trancheValues = [200, 300, 500];
-      const {
-        bond,
-        tranches,
-        mockCollateralToken,
-        admin,
-        signers
-      } = await loadFixture(getFixture(trancheValues));
+      const { bond, tranches, mockCollateralToken, admin, signers } = await loadFixture(getFixture(trancheValues));
       const [userA, userB, userC] = signers;
 
       const amount1k = parse("1000");

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -251,7 +251,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("867185");
+      expect(gasUsed.toString()).to.equal("867197");
     });
   });
 

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -648,7 +648,7 @@ describe("Bond Controller", () => {
       const tx = await bond.connect(user).deposit(amount);
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("296833");
+      expect(gasUsed.toString()).to.equal("296714");
     });
   });
 

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -1416,7 +1416,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("158284");
+      expect(gasUsed.toString()).to.equal("158272");
     });
   });
 

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -1461,7 +1461,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("157801");
+      expect(gasUsed.toString()).to.equal("157832");
     });
   });
 

--- a/test/Tranche.ts
+++ b/test/Tranche.ts
@@ -33,10 +33,14 @@ describe("Tranche", () => {
       .createTranche("Tranche", "TRANCHE", mockCollateralToken.address);
     const receipt = await tx.wait();
 
-    let tranche;
-    if (receipt && receipt.events && receipt.events.length === 1 && receipt.events[0].args) {
-      tranche = <Tranche>await hre.ethers.getContractAt("Tranche", receipt.events[0].args.newTrancheAddress);
-    } else {
+    let tranche = undefined;
+    if (receipt && receipt.events) {
+      const trancheCreateEvent = receipt.events.find((event) => event.event === "TrancheCreated");
+      if (trancheCreateEvent && trancheCreateEvent.args) {
+        tranche = <Tranche>await hre.ethers.getContractAt("Tranche", trancheCreateEvent.args.newTrancheAddress);
+      }
+    }
+    if (!tranche) {
       throw new Error("Unable to create new tranche");
     }
 

--- a/test/Tranche.ts
+++ b/test/Tranche.ts
@@ -35,7 +35,7 @@ describe("Tranche", () => {
 
     let tranche = undefined;
     if (receipt && receipt.events) {
-      const trancheCreateEvent = receipt.events.find((event) => event.event === "TrancheCreated");
+      const trancheCreateEvent = receipt.events.find(event => event.event === "TrancheCreated");
       if (trancheCreateEvent && trancheCreateEvent.args) {
         tranche = <Tranche>await hre.ethers.getContractAt("Tranche", trancheCreateEvent.args.newTrancheAddress);
       }
@@ -248,7 +248,7 @@ describe("Tranche", () => {
       await mockCollateralToken.mint(tranche.address, amount.div(10000));
 
       await expect(tranche.connect(user).redeem(await other.getAddress(), await other.getAddress(), amount)).to.be
-        .reverted
+        .reverted;
     });
   });
 });

--- a/test/Tranche.ts
+++ b/test/Tranche.ts
@@ -4,18 +4,18 @@ import { BigNumber, Signer } from "ethers";
 import { deploy } from "./utils/contracts";
 const { loadFixture } = waffle;
 
-import { MockERC20, MockERC20CustomDecimals, Tranche, TrancheFactory } from "../typechain";
+import { MockRebasingERC20, Tranche, TrancheFactory } from "../typechain";
 
 interface TestContext {
   tranche: Tranche;
   trancheFactory: TrancheFactory;
-  mockCollateralToken: MockERC20;
+  mockCollateralToken: MockRebasingERC20;
   user: Signer;
   other: Signer;
   signers: Signer[];
 }
 
-describe("Tranche Token", () => {
+describe("Tranche", () => {
   /**
    * Sets up a test context, deploying new contracts and returning them for use in a test
    */
@@ -25,8 +25,8 @@ describe("Tranche Token", () => {
     const trancheImplementation = <Tranche>await deploy("Tranche", signers[0], []);
     const trancheFactory = <TrancheFactory>await deploy("TrancheFactory", signers[0], [trancheImplementation.address]);
 
-    const mockCollateralToken = <MockERC20CustomDecimals>(
-      await deploy("MockERC20CustomDecimals", signers[0], ["Mock ERC20", "MOCK", collateralTokenDecimals])
+    const mockCollateralToken = <MockRebasingERC20>(
+      await deploy("MockRebasingERC20", signers[0], ["Mock ERC20", "MOCK", collateralTokenDecimals])
     );
     const tx = await trancheFactory
       .connect(signers[0])
@@ -241,10 +241,10 @@ describe("Tranche Token", () => {
       const { mockCollateralToken, tranche, user, other } = await loadFixture(fixture);
       const amount = hre.ethers.constants.MaxUint256;
       await tranche.connect(user).mint(await other.getAddress(), amount);
-      await mockCollateralToken.mint(tranche.address, amount);
+      await mockCollateralToken.mint(tranche.address, amount.div(10000));
 
       await expect(tranche.connect(user).redeem(await other.getAddress(), await other.getAddress(), amount)).to.be
-        .reverted;
+        .reverted
     });
   });
 });

--- a/test/UniV2LoanRouter.ts
+++ b/test/UniV2LoanRouter.ts
@@ -7,6 +7,7 @@ const { loadFixture } = waffle;
 
 import {
   MockERC20,
+  MockRebasingERC20,
   MockUniV2Router,
   Tranche,
   TrancheFactory,
@@ -17,7 +18,7 @@ import {
 
 interface TestContext {
   router: UniV2LoanRouter;
-  mockCollateralToken: MockERC20;
+  mockCollateralToken: MockRebasingERC20;
   mockCashToken: MockERC20;
   bond: BondController;
   tranches: Tranche[];
@@ -39,7 +40,7 @@ describe("Uniswap V2 Loan Router", () => {
     const mockUniV2Router = <MockUniV2Router>await deploy("MockUniV2Router", signers[0], []);
     const router = <UniV2LoanRouter>await deploy("UniV2LoanRouter", signers[0], [mockUniV2Router.address]);
 
-    const mockCollateralToken = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
+    const mockCollateralToken = <MockRebasingERC20>await deploy("MockRebasingERC20", signers[0], ["Mock Rebasing ERC20", "MOCK-REBASE", 18]);
     const mockCashToken = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
 
     const trancheImplementation = <Tranche>await deploy("Tranche", admin, []);

--- a/test/UniV2LoanRouter.ts
+++ b/test/UniV2LoanRouter.ts
@@ -40,7 +40,9 @@ describe("Uniswap V2 Loan Router", () => {
     const mockUniV2Router = <MockUniV2Router>await deploy("MockUniV2Router", signers[0], []);
     const router = <UniV2LoanRouter>await deploy("UniV2LoanRouter", signers[0], [mockUniV2Router.address]);
 
-    const mockCollateralToken = <MockRebasingERC20>await deploy("MockRebasingERC20", signers[0], ["Mock Rebasing ERC20", "MOCK-REBASE", 18]);
+    const mockCollateralToken = <MockRebasingERC20>(
+      await deploy("MockRebasingERC20", signers[0], ["Mock Rebasing ERC20", "MOCK-REBASE", 18])
+    );
     const mockCashToken = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
 
     const trancheImplementation = <Tranche>await deploy("Tranche", admin, []);

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -395,7 +395,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("499661");
+      expect(gasUsed.toString()).to.equal("499430");
     });
   });
 });
@@ -882,7 +882,7 @@ describe("Uniswap V3 Loan Router with wrapper", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("585302");
+      expect(gasUsed.toString()).to.equal("585071");
     });
   });
 });

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -395,7 +395,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("499694");
+      expect(gasUsed.toString()).to.equal("499661");
     });
   });
 });
@@ -882,7 +882,7 @@ describe("Uniswap V3 Loan Router with wrapper", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("585335");
+      expect(gasUsed.toString()).to.equal("585302");
     });
   });
 });

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -392,7 +392,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("482158");
+      expect(gasUsed.toString()).to.equal("501880");
     });
   });
 });
@@ -879,7 +879,7 @@ describe("Uniswap V3 Loan Router with wrapper", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("567834");
+      expect(gasUsed.toString()).to.equal("587664");
     });
   });
 });

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -393,7 +393,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("500780");
+      expect(gasUsed.toString()).to.equal("499682");
     });
   });
 });
@@ -880,7 +880,7 @@ describe("Uniswap V3 Loan Router with wrapper", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("586681");
+      expect(gasUsed.toString()).to.equal("585323");
     });
   });
 });

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -395,7 +395,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("499430");
+      expect(gasUsed.toString()).to.equal("499335");
     });
   });
 });
@@ -882,7 +882,7 @@ describe("Uniswap V3 Loan Router with wrapper", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("585071");
+      expect(gasUsed.toString()).to.equal("584976");
     });
   });
 });

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -7,6 +7,7 @@ const { loadFixture } = waffle;
 
 import {
   MockERC20,
+  MockRebasingERC20,
   MockButtonWrapper,
   MockSwapRouter,
   Tranche,
@@ -18,7 +19,7 @@ import {
 
 interface TestContext {
   router: UniV3LoanRouter;
-  mockCollateralToken: MockERC20;
+  mockCollateralToken: MockRebasingERC20;
   mockCashToken: MockERC20;
   bond: BondController;
   tranches: Tranche[];
@@ -40,7 +41,7 @@ describe("Uniswap V3 Loan Router", () => {
     const mockSwapRouter = <MockSwapRouter>await deploy("MockSwapRouter", admin, []);
     const router = <UniV3LoanRouter>await deploy("UniV3LoanRouter", admin, [mockSwapRouter.address]);
 
-    const mockCollateralToken = <MockERC20>await deploy("MockERC20", admin, ["Mock ERC20", "MOCK"]);
+    const mockCollateralToken = <MockRebasingERC20>await deploy("MockRebasingERC20", signers[0], ["Mock Rebasing ERC20", "MOCK-REBASE", 18]);
     const mockCashToken = <MockERC20>await deploy("MockERC20", admin, ["Mock ERC20", "MOCK"]);
 
     const trancheImplementation = <Tranche>await deploy("Tranche", admin, []);
@@ -392,7 +393,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("501880");
+      expect(gasUsed.toString()).to.equal("500780");
     });
   });
 });
@@ -879,7 +880,7 @@ describe("Uniswap V3 Loan Router with wrapper", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("587664");
+      expect(gasUsed.toString()).to.equal("586681");
     });
   });
 });

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -395,7 +395,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("499335");
+      expect(gasUsed.toString()).to.equal("499271");
     });
   });
 });
@@ -882,7 +882,7 @@ describe("Uniswap V3 Loan Router with wrapper", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("584976");
+      expect(gasUsed.toString()).to.equal("584912");
     });
   });
 });

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -395,7 +395,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("499756");
+      expect(gasUsed.toString()).to.equal("499774");
     });
   });
 });
@@ -882,7 +882,7 @@ describe("Uniswap V3 Loan Router with wrapper", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("585397");
+      expect(gasUsed.toString()).to.equal("585415");
     });
   });
 });

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -393,7 +393,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("499682");
+      expect(gasUsed.toString()).to.equal("499756");
     });
   });
 });
@@ -880,7 +880,7 @@ describe("Uniswap V3 Loan Router with wrapper", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("585323");
+      expect(gasUsed.toString()).to.equal("585397");
     });
   });
 });

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -41,7 +41,9 @@ describe("Uniswap V3 Loan Router", () => {
     const mockSwapRouter = <MockSwapRouter>await deploy("MockSwapRouter", admin, []);
     const router = <UniV3LoanRouter>await deploy("UniV3LoanRouter", admin, [mockSwapRouter.address]);
 
-    const mockCollateralToken = <MockRebasingERC20>await deploy("MockRebasingERC20", signers[0], ["Mock Rebasing ERC20", "MOCK-REBASE", 18]);
+    const mockCollateralToken = <MockRebasingERC20>(
+      await deploy("MockRebasingERC20", signers[0], ["Mock Rebasing ERC20", "MOCK-REBASE", 18])
+    );
     const mockCashToken = <MockERC20>await deploy("MockERC20", admin, ["Mock ERC20", "MOCK"]);
 
     const trancheImplementation = <Tranche>await deploy("Tranche", admin, []);

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -395,7 +395,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("499774");
+      expect(gasUsed.toString()).to.equal("499694");
     });
   });
 });
@@ -882,7 +882,7 @@ describe("Uniswap V3 Loan Router with wrapper", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("585415");
+      expect(gasUsed.toString()).to.equal("585335");
     });
   });
 });

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("754595");
+      expect(gasUsed.toString()).to.equal("774445");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("771292");
+      expect(gasUsed.toString()).to.equal("771282");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("771712");
+      expect(gasUsed.toString()).to.equal("771777");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("771301");
+      expect(gasUsed.toString()).to.equal("771292");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("771865");
+      expect(gasUsed.toString()).to.equal("771785");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("771387");
+      expect(gasUsed.toString()).to.equal("771292");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("771777");
+      expect(gasUsed.toString()).to.equal("771865");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("771752");
+      expect(gasUsed.toString()).to.equal("771387");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("771785");
+      expect(gasUsed.toString()).to.equal("771752");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("774445");
+      expect(gasUsed.toString()).to.equal("773240");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("771282");
+      expect(gasUsed.toString()).to.equal("771301");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("771282");
+      expect(gasUsed.toString()).to.equal("771292");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("773240");
+      expect(gasUsed.toString()).to.equal("771712");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("682997");
+      expect(gasUsed.toString()).to.equal("702812");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("700374");
+      expect(gasUsed.toString()).to.equal("700448");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("700448");
+      expect(gasUsed.toString()).to.equal("700536");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("700456");
+      expect(gasUsed.toString()).to.equal("700424");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("700048");
+      expect(gasUsed.toString()).to.equal("699953");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("701643");
+      expect(gasUsed.toString()).to.equal("700374");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("700424");
+      expect(gasUsed.toString()).to.equal("700048");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("699953");
+      expect(gasUsed.toString()).to.equal("699963");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("702812");
+      expect(gasUsed.toString()).to.equal("701643");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("700536");
+      expect(gasUsed.toString()).to.equal("700456");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,6 +1556,12 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
+"ampleforth-contracts@https://github.com/ampleforth/ampleforth-contracts#v1.2.1":
+  version "0.0.1"
+  resolved "https://github.com/ampleforth/ampleforth-contracts#f65dc30e4aae0624345a58d37f5c91f385850166"
+  dependencies:
+    openzeppelin-contracts-4.4.1 "https://github.com/OpenZeppelin/openzeppelin-contracts.git#4.4.1"
+
 ansi-colors@3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
@@ -7855,6 +7861,10 @@ opencollective-postinstall@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
+
+"openzeppelin-contracts-4.4.1@https://github.com/OpenZeppelin/openzeppelin-contracts.git#4.4.1":
+  version "4.4.1"
+  resolved "https://github.com/OpenZeppelin/openzeppelin-contracts.git#6bd6b76d1156e20e45d1016f355d154141c7e5b9"
 
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,9 +1556,9 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-"ampleforth-contracts@https://github.com/ampleforth/ampleforth-contracts.git#v1.2.1":
+"ampleforth-contracts@https://github.com/ampleforth/ampleforth-contracts#v1.2.1":
   version "0.0.1"
-  resolved "https://github.com/ampleforth/ampleforth-contracts.git#f65dc30e4aae0624345a58d37f5c91f385850166"
+  resolved "https://github.com/ampleforth/ampleforth-contracts#f65dc30e4aae0624345a58d37f5c91f385850166"
   dependencies:
     openzeppelin-contracts-4.4.1 "https://github.com/OpenZeppelin/openzeppelin-contracts.git#4.4.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,9 +1556,9 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-"ampleforth-contracts@https://github.com/ampleforth/ampleforth-contracts#v1.2.1":
+"ampleforth-contracts@https://github.com/ampleforth/ampleforth-contracts.git#v1.2.1":
   version "0.0.1"
-  resolved "https://github.com/ampleforth/ampleforth-contracts#f65dc30e4aae0624345a58d37f5c91f385850166"
+  resolved "https://github.com/ampleforth/ampleforth-contracts.git#f65dc30e4aae0624345a58d37f5c91f385850166"
   dependencies:
     openzeppelin-contracts-4.4.1 "https://github.com/OpenZeppelin/openzeppelin-contracts.git#4.4.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,10 +880,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
   integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
 
-"@openzeppelin/contracts@^4.4.1":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
-  integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
+"@openzeppelin/contracts@^4.8.0":
+  version "4.8.0"
+  resolved "https://npm.buttonwood.dev/@openzeppelin%2fcontracts/-/contracts-4.8.0.tgz#6854c37df205dd2c056bdfa1b853f5d732109109"
+  integrity sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==
 
 "@rari-capital/solmate@^6.4.0":
   version "6.4.0"


### PR DESCRIPTION
## Changes:
- Adding Virtual Scaled Collateral Balance Tracking into deposit/redeem
  - Ignores extraneousCollateral when depositing, early-redeeming, and mature-redeeming
- Extraneous Collateral is transferred to admin at the beginning of deposit, early-redeeming, and maturation
    -  Simplified logic with a single wrapping modifier, `onSkim`
- Add Math.mulDiv into deposit-router (more robust for coins with huge numbers of decimals)
- Added `collateralBalance() external view` to view non-extraneous collateral
- Removing 0 from `enforce_total_debt` check to keep bond from emptying

## Tests:
- Added test to validate correct number of tokens are minted after extraneous collateral is injected
- Added additional tests to make sure correct amounts are redeemed after extraneous collateral 
- Added an ampl-specific test that uses real contracts

## Reviewers:
@Fiddlekins 
@aalavandhan 
@marktoda 