### PR TITLE
perf(bond-controller): consolidate loops, remove array allocation, gas optimization

### DIFF
--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -649,7 +649,7 @@ describe("Bond Controller", () => {
       const tx = await bond.connect(user).deposit(amount);
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("293967");
+      expect(gasUsed.toString()).to.equal("293579");
     });
   });
 

--- a/test/BondController.ts
+++ b/test/BondController.ts
@@ -649,7 +649,7 @@ describe("Bond Controller", () => {
       const tx = await bond.connect(user).deposit(amount);
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("296633");
+      expect(gasUsed.toString()).to.equal("293967");
     });
   });
 
@@ -1464,7 +1464,7 @@ describe("Bond Controller", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("157707");
+      expect(gasUsed.toString()).to.equal("157695");
     });
   });
 

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -395,7 +395,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("499271");
+      expect(gasUsed.toString()).to.equal("498738");
     });
   });
 });
@@ -882,7 +882,7 @@ describe("Uniswap V3 Loan Router with wrapper", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("584912");
+      expect(gasUsed.toString()).to.equal("584379");
     });
   });
 });

--- a/test/UniV3LoanRouter.ts
+++ b/test/UniV3LoanRouter.ts
@@ -395,7 +395,7 @@ describe("Uniswap V3 Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("498738");
+      expect(gasUsed.toString()).to.equal("498428");
     });
   });
 });
@@ -882,7 +882,7 @@ describe("Uniswap V3 Loan Router with wrapper", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("584379");
+      expect(gasUsed.toString()).to.equal("584068");
     });
   });
 });

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("770759");
+      expect(gasUsed.toString()).to.equal("770448");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WamplLoanRouter.ts
+++ b/test/WamplLoanRouter.ts
@@ -673,7 +673,7 @@ describe("WAMPL Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("771292");
+      expect(gasUsed.toString()).to.equal("770759");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("699963");
+      expect(gasUsed.toString()).to.equal("699430");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),

--- a/test/WethLoanRouter.ts
+++ b/test/WethLoanRouter.ts
@@ -578,7 +578,7 @@ describe("WETH Loan Router", () => {
 
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("699430");
+      expect(gasUsed.toString()).to.equal("699120");
       const costOfGas = gasUsed.mul(receipt.effectiveGasPrice);
       expect(await user.getBalance()).to.eq(
         startingBalance.sub(amount).sub(costOfGas),


### PR DESCRIPTION
### Changes:

- consolidate two loops in to one, all data is available and relevant in first pass
- remove array allocation, it is unnecessary when using only one loop
- less gas is used, and code is easier to understand
### Test:

- updated tests to pass with less gas being used